### PR TITLE
Upgrade docs module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 talisker[gunicorn]==0.14.3
-canonicalwebteam.discourse_docs==0.4.1
+canonicalwebteam.discourse-docs==0.5.0
 canonicalwebteam.flask_base==0.2.0
 canonicalwebteam.http==1.0.1
 canonicalwebteam.templatefinder==0.1.1


### PR DESCRIPTION
Use version 0.5.0 of canoncalwebteam.discourse-docs, with proper support for docs under `/docs`.

QA
--

The same QA steps as in https://github.com/canonical-web-and-design/canonicalwebteam.discourse-docs/pull/10:

`./run clean && ./run`

Check:

- [x] https://maas-io-canonical-web-and-design-pr-348.run.demo.haus/ loads properly
- [x] https://maas-io-canonical-web-and-design-pr-348.run.demo.haus/docs loads properly
- [x] Links in nav have pretty URLs (e.g. `/docs/explore-maas`)
- [x] Links in page also have pretty URLs
- [x] Pretty links work (e.g. https://maas-io-canonical-web-and-design-pr-348.run.demo.haus/docs/explore-maas)
- [x] Ugly links redirect to pretty links (e.g. https://maas-io-canonical-web-and-design-pr-348.run.demo.haus/docs/t/any-slug/789 or https://maas-io-canonical-web-and-design-pr-348.run.demo.haus/docs/t/any-slug/840)
- [x] Do some other clicking around