### PR TITLE
MAAS docs template tidy up

### DIFF
--- a/static/sass/_patterns_docs.scss
+++ b/static/sass/_patterns_docs.scss
@@ -37,6 +37,10 @@
     @media only screen and (max-width: $breakpoint-navigation-threshold) {
       flex: auto;
     }
+
+    .meta {
+      display: none;
+    }
   }
 
   .l-docs-row {

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -45,5 +45,15 @@
         sidebarContent.classList.toggle('u-hide--small');
       });
     });
+
+    // Add active links to active nav item and scroll to section
+    var sidebar = document.querySelector(".l-docs-sidebar");
+    document.querySelectorAll('.p-sidenav__body ul a').forEach(function(anchor) {
+      if (anchor.pathname === location.pathname) {
+        anchor.classList.add('is-active');
+        var section = anchor.closest("ul");
+        sidebar.scrollTo(0, section.offsetTop - 40);
+      }
+    });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Done
- Hid the link below images.
- Added to highlight the selected item in the left nav and scroll to it.

## QA
- Go to any page with images (e.g. /docs or /explore-maas) and check that there is no longer a link below it
- Go to any page and check that the correct item in the sidebar is highlighted
- Go to a different section and check that the sidebar scrolls to the section correctly

Fixes canonical-web-and-design/MAAS-squad#1319
