### PR TITLE
Remove image versions from pricing table

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -598,20 +598,6 @@ document.addEventListener('DOMContentLoaded', function () {
               <td>24 hours a day, everyday</td>
             </tr>
             <tr>
-              <td>Ubuntu and CentOS deployment</td>
-              <td><img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
-              <td><img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
-              <td><img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
-              <td><img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
-            </tr>
-            <tr>
-              <td>Windows, RHEL, and custom image<br> creation and deployment</td>
-              <td>&ndash;</td>
-              <td><img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
-              <td><img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
-              <td><img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
-            </tr>
-            <tr>
               <td>Response time - SLA Sev 1</td>
               <td>&ndash;</td>
               <td>&ndash;</td>


### PR DESCRIPTION
## Done
Remove image versions from pricing table as per the copy doc.

## QA
- Go to http://0.0.0.0:8006/
- Scroll down to the "Enterprise support for MAAS" section
- Check that the table matches [the copy doc](https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit#)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/maas.io/issues/362

## Screenshots
![Screenshot_2019-07-17 Metal as a Service MAAS](https://user-images.githubusercontent.com/1413534/61398569-30f61200-a8c4-11e9-8f71-ca4115838ece.png)
