### PR TITLE
Use discourse-docs v0.6.2 to get /docs/sitemap.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 talisker[gunicorn]==0.14.3
-canonicalwebteam.discourse-docs==0.6.1
+canonicalwebteam.discourse-docs==0.6.2
 canonicalwebteam.flask_base==0.3.1
 canonicalwebteam.http==1.0.1
 canonicalwebteam.templatefinder==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 talisker[gunicorn]==0.14.3
-canonicalwebteam.discourse-docs==0.6.0
+canonicalwebteam.discourse-docs==0.6.1
 canonicalwebteam.flask_base==0.3.1
 canonicalwebteam.http==1.0.1
 canonicalwebteam.templatefinder==0.1.2

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -47,7 +47,7 @@ discourse_docs.init_app(app)
 app.add_url_rule(
     "/docs/search",
     "docs-search",
-    build_search_view(site="docs.maas.io", template_path="docs/search.html"),
+    build_search_view(site="maas.io/docs", template_path="docs/search.html"),
 )
 
 


### PR DESCRIPTION
This is so I can pass `/docs/sitemap.txt` to Google to index.

Change docs.maas.io to maas.io/docs.

## QA

`./run --env SEARCH_API_KEY={thekey}`, go to `/docs/sitemap.txt` and see it in all its glory.

Go to `/docs/search`, search for things, see the results returned are at `maas.io/docs`.