### PR TITLE
discourse-docs v0.6.4 for domain in /docs/sitemap.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 talisker[gunicorn]==0.14.3
-canonicalwebteam.discourse-docs==0.6.3
+canonicalwebteam.discourse-docs==0.6.4
 canonicalwebteam.flask_base==0.3.1
 canonicalwebteam.http==1.0.1
 canonicalwebteam.templatefinder==0.1.2


### PR DESCRIPTION
QA
--

Go to `/docs/sitemap.txt` and see the domain in the URLs.