### PR TITLE
Highlight /docs in search results too

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,5 +1,5 @@
 get-started: "/install"
-index.html: "/"
+(?P<path>.*)/index(.html)?: "{path}"
 
 # Docs redirects
 docs/(devel|2.6|stable|en|devel/en|stable/en|2.6/en): /docs

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -21,23 +21,23 @@
 
     <nav class="p-navigation__nav">
       <ul id="main-navigation" class="p-navigation__links u-clearfix">
-        <li class="p-navigation__link{% if level_1 == 'install' %} is-selected" aria-current="page{% endif %}">
+        <li class="p-navigation__link{% if request.path.startswith('/install') %} is-selected" aria-current="page{% endif %}">
           <a href="/install" dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Install' });>Install</a>
         </li>
-        <li class="p-navigation__link{% if level_1 == 'how-it-works' %} is-selected" aria-current="page{% endif %}">
+        <li class="p-navigation__link{% if request.path.startswith('/how-it-works') %} is-selected" aria-current="page{% endif %}">
           <a href="/how-it-works" dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'Main navigation'
             , 'eventAction' : 'Click' , 'eventLabel' : 'How it works' });>How it works</a>
         </li>
-        <li class="p-navigation__link{% if level_1 == 'tour' %} is-selected" aria-current="page{% endif %}">
+        <li class="p-navigation__link{% if request.path.startswith('/tour') %} is-selected" aria-current="page{% endif %}">
           <a href="/tour" dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Tour' });>Tour</a>
         </li>
-        <li class="p-navigation__link{% if document %} is-selected" aria-current="page{% endif %}">
+        <li class="p-navigation__link{% if request.path.startswith('/docs') %} is-selected" aria-current="page{% endif %}">
           <a href="/docs" dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Docs' });>Docs</a>
         </li>
         <li class="p-navigation__link">
           <a class="p-link--external" href="https://discourse.maas.io" aria-label="External link to the MAAS discourse website" dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Discourse' });>Forum</a>
         </li>
-        <li class="p-navigation__link{% if level_1 == 'contact-us' %} is-selected" aria-current="page{% endif %}">
+        <li class="p-navigation__link{% if request.path.startswith('/contact-us') %} is-selected" aria-current="page{% endif %}">
           <a href="/contact-us" class="js-invoke-modal" dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Contact us' });>Contact us</a>
         </li>
       </ul>


### PR DESCRIPTION
Also redirect /docs/index to /docs, to fix people kicked over from old-docs.

QA
--

Go to `/docs/search?q=machines` - see the "docs" item in the nav is dark.

Go to `/docs/index`, check you end up at `/docs`.