### PR TITLE
Fix redirect to old docs

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -5,7 +5,8 @@ index(.html)?: "/"
 # Docs redirects
 docs/(devel|2.6|stable|en|devel/en|stable/en|2.6/en): /docs
 docs/(devel|2.6|stable|en|devel/en|stable/en|2.6/en)/(?P<path>.*): /docs/{path}
-docs/(?P<version>2.5|2.4|2.3|2.2|2.1|2.0|1.9)(/en)?(?P<path>(/.*)?): https://old-docs.maas.io/{version}/en/{path}
+docs/(?P<version>2.5|2.4|2.3|2.2|2.1|2.0|1.9)(/en)?/?: https://old-docs.maas.io/{version}/en/
+docs/(?P<version>2.5|2.4|2.3|2.2|2.1|2.0|1.9)(/en)?/(?P<path>.+): https://old-docs.maas.io/{version}/en/{path}
 
 # Specific paths
 docs/contributing-build: /docs/building-the-docs


### PR DESCRIPTION
QA
--

`./run`, go to http://0.0.0.0:8006/docs/2.5/en/nodes-add, get redirected to old-docs, click the drop-down, select 2.6, check you end up on a good page on maas.io/docs.