### PR TITLE
fix broken mobile classes

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -197,7 +197,7 @@
     </div>
     <div class="row js-logo-strip">
         <noscript>
-            <div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/4c6fb640-logo-verizon.png" alt="verizon logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/252e2017-logo-ea.png" alt="ea logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/e7dd8cc4-logo-at%26t.png" alt="AT&amp;T logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/add4119e-logo-sandia.png" alt="SNL logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/afb5991e-logo-ubisoft.png" alt="ubisoft logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/ab9074df-logo-tele2.png" alt="tele2 logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/56c03384-logo-nec.png" alt="nec logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/822701bb-logo-tmobile.png" alt="tmobile logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/673fa219-logo-ntt.png" alt="ntt logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png" alt="bt logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/a59ea622-logo-liberty-global.png" alt="liberty-global logo"></div><div class="mobile-col-1 tablet-col-1 col-2"><img src="https://assets.ubuntu.com/v1/9bb88cf6-logo-barclays+copy.png" alt="barclays logo"></div>
+            <div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/4c6fb640-logo-verizon.png" alt="verizon logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/252e2017-logo-ea.png" alt="ea logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/e7dd8cc4-logo-at%26t.png" alt="AT&amp;T logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/add4119e-logo-sandia.png" alt="SNL logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/afb5991e-logo-ubisoft.png" alt="ubisoft logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/ab9074df-logo-tele2.png" alt="tele2 logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/56c03384-logo-nec.png" alt="nec logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/822701bb-logo-tmobile.png" alt="tmobile logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/673fa219-logo-ntt.png" alt="ntt logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png" alt="bt logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/a59ea622-logo-liberty-global.png" alt="liberty-global logo"></div><div class="col-small-1 col-medium-1 col-2"><img src="https://assets.ubuntu.com/v1/9bb88cf6-logo-barclays+copy.png" alt="barclays logo"></div>
         </noscript>
     </div>
 </section>
@@ -241,33 +241,22 @@ var logoStripTwoData = {
 
 var logoStripRevealingModule = (function() {
     var target,
-        colClassesList,
-        firstColClassesList;
+        colClassesList;
 
     target = document.querySelector('.js-logo-strip');
 
     colClassesList = {
-        mobile: "mobile-col-1",
-        tablet: "tablet-col-1",
+        mobile: "col-small-1",
+        tablet: "col-medium-1",
         desktop: "col-2"
     };
 
-    firstColClassesList = {
-        mobileFirstCol:  "u-first-col--mobile",
-        tabletFirstCol:  "u-first-col--tablet",
-        desktopFirstCol: "u-first-col--desktop"
-    };
-
-    function appendLogo(parent, logoDatum, firstColClasses) {
+    function appendLogo(parent, logoDatum) {
         var logoWrapper = document.createElement('div'),
             logoImg = document.createElement('img');
 
         for (var className in colClassesList) {
           logoWrapper.classList.add(colClassesList[className]);
-        }
-
-        for (var className in firstColClasses) {
-          logoWrapper.classList.add(firstColClasses[className]);
         }
 
         logoImg.setAttribute('src', 'https://assets.ubuntu.com/v1/' + logoDatum.url);
@@ -280,19 +269,8 @@ var logoStripRevealingModule = (function() {
         var fragment = document.createDocumentFragment();
 
         Object.keys(logoStripData).forEach(function (key, index) {
-            var logoDatum = logoStripData[key],
-                firstColClasses = [];
-
-            if (index % 4 == 0) {
-                firstColClasses.push(firstColClassesList.mobileFirstCol);
-            }
-
-            if (index % 6 == 0) {
-                firstColClasses.push(firstColClassesList.tabletFirstCol);
-                firstColClasses.push(firstColClassesList.desktopFirstCol);
-            }
-
-            appendLogo(fragment, logoDatum, firstColClasses);
+            var logoDatum = logoStripData[key];
+            appendLogo(fragment, logoDatum);
         });
 
         target.appendChild(fragment);


### PR DESCRIPTION
## Done
Due to a name change ()mobile-col-* -> col-small-*
mobile / tablet view of the logo strip looks broken. This update fixes the class names so it works again.
I've also removed the first column utilities as the new grid doesn't need them.
## QA

Open homepage, logos appear 4 on a row on mobile, 6 on tablet and desktop.

## Issue / Card


## Screenshots
Before:
![image](https://user-images.githubusercontent.com/2741678/62477770-90e42800-b7a1-11e9-83b7-e6e6dbd21eb2.png)

after:
![image](https://user-images.githubusercontent.com/2741678/62477690-62664d00-b7a1-11e9-9c2a-06091cb00fde.png)


