### PR TITLE
Remove close button from the vmware-images page

### DIFF
--- a/templates/vmware-images.html
+++ b/templates/vmware-images.html
@@ -50,7 +50,6 @@
             </div>
             <p>In submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/data-privacy">Canonical&rsquo;s Privacy Notice</a> and <a href="https://www.ubuntu.com/legal/data-privacy/esxi">Privacy Policy</a>.
             <div class="p-form__group mktField">
-              <button type="button" class="mktoButton p-button--neutral close-modal">Cancel</button>
               <button type="submit" class="mktoButton p-button--positive">Download template</button>
             </div>
             <input type="hidden" name="formid" class="mktoField" value="3392">


### PR DESCRIPTION
## Done
Remove close button from the vmware-images page

## QA
- Go to /vmware-images
- See there is no Close button at the bottom of the form
