### PR TITLE
Layout the three audiences section

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -59,3 +59,34 @@ table + h2 {
 .lightbox-wrapper {
   margin-bottom: 1.1rem;
 }
+
+.p-heading-icon-block {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+
+  @media only screen and (min-width: $breakpoint-medium) {
+    margin-bottom: 2rem;
+  }
+}
+
+.p-heading-icon-block__copy-block {
+  margin-top: -0.5rem;
+}
+
+.p-heading-icon-block__icon {
+  border-radius: 0;
+  height: auto;
+  margin-bottom: $spv-inner--small;
+  margin-right: $sph-inner;
+  padding-right: $sph-inner;
+  width: ($sp-unit * 5) + $sph-inner;
+}
+
+.u-indent {
+  @media only screen and (min-width: $breakpoint-medium) {
+    float: right;
+    width: calc(100% - 8.5rem);
+  }
+}

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -72,7 +72,7 @@ table + h2 {
 }
 
 .p-heading-icon-block__copy-block {
-  margin-top: -0.5rem;
+  margin-top: -.5rem;
 }
 
 .p-heading-icon-block__icon {

--- a/templates/index.html
+++ b/templates/index.html
@@ -328,6 +328,67 @@ document.addEventListener('DOMContentLoaded', function () {
   </div>
 </section>
 
+<section class="p-strip">
+  <div class="row">
+    <h2>Real world MAAS</h2>
+  </div>
+  <div class="row">
+    <div class="col-4">
+      <div class="p-heading-icon-block">
+        <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/0ae9bd9c-MAAS-Real+world+icon-Flexibility.svg" style="padding: 1rem 1rem 1rem 0;" />
+        <div class="p-heading-icon-block__copy-block">
+          <h5 class="u-min-margin--bottom">Flexibility</h5>
+          <p class="p-muted-heading u-min-margin--bottom">Edge</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <h4><a href="https://ubuntu.com/blog/maas-2-5-growing-the-ecosystem-and-support-for-kvm-micro-clouds">MAAS KVM for micro-clouds and edge computing</a></h4>
+      <p>Blog post</p>
+    </div>
+    <div class="col-4">
+      <h4><a href="https://www.brighttalk.com/webcast/6793/362201/maas-at-the-edge-the-importance-of-bare-metal-provisioning-in-edge-computing">The importance of bare metal provisioning in edge computing</a></h4>
+      <p>Webinar</p>
+    </div>
+  </div>
+  <div class="row" style="overflow:hidden;">
+    <hr class="u-indent" />
+  </div>
+  <div class="row">
+    <div class="col-4">
+      <div class="p-heading-icon-block">
+        <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/89815b24-MAAS-Real+world+icon-Ease-of-use.svg" />
+        <div class="p-heading-icon-block__copy-block">
+          <h5 class="u-min-margin--bottom">Ease of use</h5>
+          <p class="p-muted-heading u-min-margin--bottom">Small &amp; medium business</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <h4><a href="https://ubuntu.com/blog/maas-fast-efficient-virtualisation-sme">MAAS &mdash; Fast and efficient virtualisation for small and medium enterprises</a></h4>
+      <p>Blog post</p>
+    </div>
+  </div>
+  <div class="row" style="overflow:hidden;">
+    <hr class="u-indent" />
+  </div>
+  <div class="row">
+    <div class="col-4">
+      <div class="p-heading-icon-block">
+        <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/36fe873f-MAAS-Real+world+icon-Scale.svg" style="padding-bottom: 0.8rem;" /s>
+        <div class="p-heading-icon-block__copy-block">
+          <h5 class="u-min-margin--bottom">Scale</h5>
+          <p class="p-muted-heading u-min-margin--bottom">Data center</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <h4><a href="https://ubuntu.com/engage/maas-hardware-testing">Large-scale automated hardware testing with MAAS</a></h4>
+      <p class="u-muted-text">Whitepaper</p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip--light">
   <div class="row">
     <div class="col-6">

--- a/templates/index.html
+++ b/templates/index.html
@@ -377,7 +377,7 @@ document.addEventListener('DOMContentLoaded', function () {
       <div class="p-heading-icon-block">
         <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/36fe873f-MAAS-Real+world+icon-Scale.svg" style="padding-bottom: 0.8rem;" /s>
         <div class="p-heading-icon-block__copy-block">
-          <h5 class="u-min-margin--bottom">Scale</h5>
+          <h5 class="u-no-margin--bottom">Scale</h5>
           <p class="p-muted-heading u-min-margin--bottom">Data center</p>
         </div>
       </div>


### PR DESCRIPTION
## Done
Rebuilt the 3 audiences content section.

## QA
- Go to the homepage
- Scroll to the Real world MAAS section
- Check it matches [the design](https://app.zeplin.io/project/5ca22b39f12ffd1bed35d14a/screen/5d39d3c4a54ac32e88b15e76) but with more content now.
- Check it matches [the copy doc](https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit?disco=AAAADaV9f_c&ts=5d557b6b&usp_dm=true)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/maas.io/issues/327

## Screenshots
![Screenshot_2019-08-15 Metal as a Service MAAS](https://user-images.githubusercontent.com/1413534/63114960-162fbf80-bf8e-11e9-9b0a-ddb15425845d.png)

