### PR TITLE
Trivial: Fix use of phrasal verb “log in”

### DIFF
--- a/templates/install.html
+++ b/templates/install.html
@@ -60,7 +60,7 @@
                       <input class="p-code-copyable__input" value="sudo maas init" readonly="readonly">
                       <button class="p-code-copyable__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
                   </div>
-                  <p>Login to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
+                  <p>Log in to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
                 </div>
               </li>
               <li class="p-stepped-list__item">


### PR DESCRIPTION
“Login” is a noun; “log in” is a verb.

(Inspired by [this 18-year-old bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=103439) by @matthewpaulthomas :smiley:)