### PR TITLE
Increase analytics site speed sampling

### DIFF
--- a/templates/includes/tag_manager.html
+++ b/templates/includes/tag_manager.html
@@ -3,7 +3,7 @@
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', 'UA-1018242-58', 'auto', {'allowLinker': true});
+ga('create', 'UA-1018242-58', 'auto', {'allowLinker': true, 'siteSpeedSampleRate': 100});
 ga('require', 'GTM-N953L4W');
 ga('require', 'linker');
 ga('linker:autoLink', ['conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',


### PR DESCRIPTION
## Done

Add a parameter to the Google Analytics config object to increase the sample site speed data.

## QA

- Inspect the source of any page
- Look for the line that includes `ga('create', 'UA-1018242-58',`
- See that in the options object contains `'siteSpeedSampleRate': 100`