### PR TITLE
Remove the external icon on the discourse navigation item

### DIFF
--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -35,7 +35,7 @@
           <a href="/docs" dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Docs' });>Docs</a>
         </li>
         <li class="p-navigation__link">
-          <a class="p-link--external" href="https://discourse.maas.io" aria-label="External link to the MAAS discourse website" dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Discourse' });>Discourse</a>
+          <a href="https://discourse.maas.io" dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Discourse' });>Discourse</a>
         </li>
         <li class="p-navigation__link{% if request.path.startswith('/contact-us') %} is-selected" aria-current="page{% endif %}">
           <a href="/contact-us" class="js-invoke-modal" dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Contact us' });>Contact us</a>


### PR DESCRIPTION
## Done
Remove the external icon on the discourse navigation item as the discourse is now simularly styled.

## QA
- Check the navigation as no external icons