### PR TITLE
Surify  maas.io homepage banner

### DIFF
--- a/static/sass/_patterns_sidenav.scss
+++ b/static/sass/_patterns_sidenav.scss
@@ -14,12 +14,12 @@
 
     a,
     a:visited {
-      color: #111;
+      color: $color-dark;
       text-decoration: none;
     }
 
     a:hover {
-      color: #007aa6;
+      color: #$color-link;
       text-decoration: underline;
     }
 
@@ -27,7 +27,7 @@
       position: relative;
 
       &::before {
-        background-color: #cdcdcd;
+        background-color: $color-mid-light;
         bottom: -.25rem;
         content: '';
         left: -1rem;
@@ -38,9 +38,9 @@
     }
 
     ul {
+      margin-bottom: .625rem;
       margin-left: 0;
       padding-left: 1rem;
-      margin-bottom: .625rem;
     }
 
     li {

--- a/static/sass/_patterns_sidenav.scss
+++ b/static/sass/_patterns_sidenav.scss
@@ -19,7 +19,7 @@
     }
 
     a:hover {
-      color: #$color-link;
+      color: $color-link;
       text-decoration: underline;
     }
 

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -24,8 +24,8 @@
     }
 
     // magic numbers to make lines go through center of video playback button
-    --g2a: 51%;
-    --g2b: 50.5%;
+    --g2a: 46.5%;
+    --g2b: 55.5%;
     --g2p: 26%;
 
     background-image:
@@ -36,7 +36,7 @@
       linear-gradient(calc(var(--gr3) * -1), transparent var(--g2a), hsla(0, 0%, 100%, .05)  var(--g2a))
     ;
 
-    background-position: calc(50% + 286px) 50%;
+    background-position: 50% 50%;
     background-size: 5000px calc(103%);
     background-blend-mode: darken, screen, normal, normal, normal;
     background-repeat: no-repeat;

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -14,21 +14,21 @@
     background-blend-mode: multiply, multiply, normal, normal;
     background-color: $color-dark;
     background-image: linear-gradient(to bottom left,
-        $color-suru-grey-1 0,
-        $color-suru-grey-1 49.9%, transparent 50%),
+      $color-suru-grey-1 0,
+      $color-suru-grey-1 49.9%, transparent 50%),
       linear-gradient(to bottom right,
-        $color-suru-grey-2 0,
-        $color-suru-grey-2 49.9%,
-        transparent 50%),
+      $color-suru-grey-2 0,
+      $color-suru-grey-2 49.9%,
+      transparent 50%),
       linear-gradient(to top left,
-        $color-x-light 0%,
-        $color-x-light 49.3%,
-        transparent 50%,
-        transparent 100%),
+      $color-x-light 0%,
+      $color-x-light 49.3%,
+      transparent 50%,
+      transparent 100%),
       linear-gradient(201deg,
-        $color-suru-grey-3 0%,
-        $color-suru-grey-4 46%,
-        $color-dark 90%
+      $color-suru-grey-3 0%,
+      $color-suru-grey-4 46%,
+      $color-dark 90%
     );
     color: $color-x-light;
     background-position: top right, top left, right bottom -1px, left top;

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -10,5 +10,10 @@
     margin: 0;
     padding-bottom: 11rem;
     padding-top: 6rem;
-}
+  }
+
+  .p-takeover--no-overlays {
+    // copy of ubuntu.com's .p-takeover--compliance found at https://ubuntu.com/takeovers
+    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+  }
 }

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -1,9 +1,36 @@
 @mixin maas-p-strip--dark {
+  $color-suru-grey-1: rgba(216, 216, 216, 0.54);
+  $color-suru-grey-2: rgba(228, 228, 228, 0.54);
+  $color-suru-grey-3: #333;
+  $color-suru-grey-4: #262626;
+  $color-suru-grey-5: #171717;
+  $color-suru-grey-6: #181818;
+  $color-suru-grey-7: #2d2d2d;
+  $color-suru-grey-8: #383838;
+  $color-suru-grey-9: #2E2E2E;
+  $color-suru-grey-10: #393939;
+
   .p-takeover--dark {
     background-blend-mode: multiply, multiply, normal, normal;
-    background-color: #111;
-    background-image: linear-gradient(to bottom left, rgba(216, 216, 216, 0.54) 0, rgba(216, 216, 216, 0.54) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(228, 228, 228, 0.54) 0, rgba(228, 228, 228, 0.54) 49.9%, transparent 50%), linear-gradient(to top left, #fff 0%, #fff 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(201deg, #333 0%, #262626 46%, #111 90%);
-    color: #fff;
+    background-color: $color-dark;
+    background-image: linear-gradient(to bottom left,
+        $color-suru-grey-1 0,
+        $color-suru-grey-1 49.9%, transparent 50%),
+      linear-gradient(to bottom right,
+        $color-suru-grey-2 0,
+        $color-suru-grey-2 49.9%,
+        transparent 50%),
+      linear-gradient(to top left,
+        $color-x-light 0%,
+        $color-x-light 49.3%,
+        transparent 50%,
+        transparent 100%),
+      linear-gradient(201deg,
+        $color-suru-grey-3 0%,
+        $color-suru-grey-4 46%,
+        $color-dark 90%
+    );
+    color: $color-x-light;
     background-position: top right, top left, right bottom -1px, left top;
     background-repeat: no-repeat;
     background-size: 74% 99.83%, 68% 91%, 103.8% 20.26%, 100% 99.8%;
@@ -14,6 +41,13 @@
 
   .p-takeover--no-overlays {
     // copy of ubuntu.com's .p-takeover--compliance found at https://ubuntu.com/takeovers
-    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    background-image: linear-gradient(44deg,
+      $color-suru-grey-5 0%,
+      $color-suru-grey-6 9%,
+      $color-suru-grey-4 34%,
+      $color-suru-grey-7 67%,
+      $color-suru-grey-8 88%,
+      $color-suru-grey-9 100%,
+      $color-suru-grey-10 100%);
   }
 }

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -1,6 +1,6 @@
 @mixin maas-p-strip-slanted {
   [class^='p-strip'].is-slanted {
-    background-color: #111;
+    background-color: $color-x-dark;
     overflow: hidden;
     position: relative;
 
@@ -12,8 +12,8 @@
     }
 
     // Generate golden ratio based angles in degrees and gradient color stops in percentages
-    $golden-ratio-angles: 3, 8;
-    $golden-ratio-percentages: 1, 2, 3;
+    $golden-ratio-angles: 2, 3, 7;
+    $golden-ratio-percentages: 3;
 
     @each $i in $golden-ratio-angles {
       --gr#{$i}: #{100/pow(1.618,$i)}deg;
@@ -23,18 +23,22 @@
       --g#{$i}: #{100/pow(1.618,$i)}%;
     }
 
-    // magic number to make line go through center of video playback button
+    // magic numbers to make lines go through center of video playback button
     --g2a: 47.2%;
+    --g2b: 55.85%;
+    --g2p: 26%;
 
     background-image:
-      linear-gradient(calc(-1 * var(--gr8)), #fff var(--g3), rgba(255, 255, 255, 0) calc(var(--g3) * 1.003)),
-      linear-gradient(var(--gr3), rgba(31, 31, 31, 0.5) var(--g2), rgba(255, 255, 255, 0) var(--g2)),
-      linear-gradient(calc(var(--gr3) * -1), rgba(31, 31, 31, 0.5) var(--g2), rgba(255, 255, 255, 0) var(--g1)),
-      linear-gradient(calc(var(--gr3) * -1), rgba(31, 31, 31, 0.5) var(--g2a), rgba(255, 255, 255, 0) var(--g2a)),
-      linear-gradient(calc(var(--gr3) * -1), rgba(31, 31, 31, 0.5) var(--g2), rgba(255, 255, 255, 0) var(--g2))
+      linear-gradient(calc(var(--gr7) * 1), #99999900 var(--g2p), #f0f0f0ff var(--g2p)),
+      linear-gradient(calc(-1 * var(--gr7)), #fff var(--g3), transparent calc(var(--g3) * 1.003)),
+      linear-gradient(var(--gr2), #{transparentize(#262626, .6)} var(--g2b), transparent var(--g2b)),
+      linear-gradient(calc(var(--gr3) * -1), transparent var(--g2a), #{transparentize($color-mid-dark, .75)}  var(--g2a)),
+      linear-gradient(90deg, #333 0%, #111 33%, #000 100%)
     ;
 
-    background-position: 50% 50%, var(--g2) 50%, 50% 50%, 50% 50%, var(--g2) 50%;
+    background-position: 50% 50%;
     background-size: 5000px calc(103%);
+    background-blend-mode: multiply, normal, normal, normal;
+    background-repeat: no-repeat;
   }
 }

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -32,7 +32,7 @@
     );
     background-position: top right, top left, right bottom -1px, left top;
     background-repeat: no-repeat;
-    background-size: 74% 99.83%, 68% 91%, 103.8% 2.26%, 100% 99.8%;
+    background-size: 74% 99.83%, 68% 91%, 103.8% 20.26%, 100% 99.8%;
     color: $color-x-light;
     margin: 0;
     padding-bottom: 11rem;

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -1,18 +1,18 @@
 @mixin maas-p-strip-slanted {
   [class^='p-strip'].is-slanted {
-    background-color: $color-x-dark;
+    background-color: hsl(320, 100%, 1%);
     overflow: hidden;
     position: relative;
 
-    @media (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-medium) {
       padding: $spv-outer--deep-scaleable * 0.5 0 $spv-outer--deep-scaleable;
     }
-    @media (min-width: $breakpoint-large) {
-      padding: $spv-outer--deep-scaleable 0 $spv-outer--deep-scaleable * 2;
+    @media (min-width: $breakpoint-medium) {
+      padding: $spv-outer--deep-scaleable 0 $spv-outer--deep-scaleable * 1.5;
     }
 
     // Generate golden ratio based angles in degrees and gradient color stops in percentages
-    $golden-ratio-angles: 2, 3, 7;
+    $golden-ratio-angles: 2,3,7,8;
     $golden-ratio-percentages: 3;
 
     @each $i in $golden-ratio-angles {
@@ -24,21 +24,21 @@
     }
 
     // magic numbers to make lines go through center of video playback button
-    --g2a: 47.2%;
-    --g2b: 55.85%;
+    --g2a: 51%;
+    --g2b: 50.5%;
     --g2p: 26%;
 
     background-image:
-      linear-gradient(calc(var(--gr7) * 1), #99999900 var(--g2p), #f0f0f0ff var(--g2p)),
-      linear-gradient(calc(-1 * var(--gr7)), #fff var(--g3), transparent calc(var(--g3) * 1.003)),
-      linear-gradient(var(--gr2), #{transparentize(#262626, .6)} var(--g2b), transparent var(--g2b)),
-      linear-gradient(calc(var(--gr3) * -1), transparent var(--g2a), #{transparentize($color-mid-dark, .75)}  var(--g2a)),
-      linear-gradient(90deg, #333 0%, #111 33%, #000 100%)
+      linear-gradient(calc(var(--gr7) * 1), #f0f0f000 var(--g2p), #f0f0f0ff var(--g2p)), //light grey overlap
+      linear-gradient(calc(-1 * var(--gr7)), hsla(320, 0%, 100%, .33) 0%, hsla(0, 0%, 0%, 0) 62%), // background gradient
+      linear-gradient(calc(-1 * var(--gr8)), #fff var(--g3), transparent calc(var(--g3) * 1.003)), //white slant
+      linear-gradient(var(--gr2), hsla(0, 0%, 100%, 0.015) var(--g2b), transparent var(--g2b)),
+      linear-gradient(calc(var(--gr3) * -1), transparent var(--g2a), hsla(0, 0%, 100%, .05)  var(--g2a))
     ;
 
-    background-position: 50% 50%;
+    background-position: calc(50% + 286px) 50%;
     background-size: 5000px calc(103%);
-    background-blend-mode: multiply, normal, normal, normal;
+    background-blend-mode: darken, screen, normal, normal, normal;
     background-repeat: no-repeat;
   }
 }

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -1,44 +1,14 @@
-@mixin maas-p-strip-slanted {
-  [class^='p-strip'].is-slanted {
-    background-color: hsl(320, 100%, 1%);
-    overflow: hidden;
-    position: relative;
-
-    @media (max-width: $breakpoint-medium) {
-      padding: $spv-outer--deep-scaleable * 0.5 0 $spv-outer--deep-scaleable;
-    }
-    @media (min-width: $breakpoint-medium) {
-      padding: $spv-outer--deep-scaleable 0 $spv-outer--deep-scaleable * 1.5;
-    }
-
-    // Generate golden ratio based angles in degrees and gradient color stops in percentages
-    $golden-ratio-angles: 2,3,7,8;
-    $golden-ratio-percentages: 3;
-
-    @each $i in $golden-ratio-angles {
-      --gr#{$i}: #{100/pow(1.618,$i)}deg;
-    }
-
-    @each $i in $golden-ratio-percentages {
-      --g#{$i}: #{100/pow(1.618,$i)}%;
-    }
-
-    // magic numbers to make lines go through center of video playback button
-    --g2a: 46.5%;
-    --g2b: 55.5%;
-    --g2p: 31%;
-
-    background-image:
-      linear-gradient(calc(var(--gr7) * 1), #f0f0f000 var(--g2p), #f0f0f0ff var(--g2p)), //light grey overlap
-      linear-gradient(calc(-1 * var(--gr7)), hsla(320, 0%, 100%, .33) 0%, hsla(0, 0%, 0%, 0) 62%), // background gradient
-      linear-gradient(calc(-1 * var(--gr8)), #fff var(--g3), transparent calc(var(--g3) * 1.003)), //white slant
-      linear-gradient(var(--gr2), hsla(0, 0%, 100%, 0.015) var(--g2b), transparent var(--g2b)),
-      linear-gradient(calc(var(--gr3) * -1), transparent var(--g2a), hsla(0, 0%, 100%, .05)  var(--g2a))
-    ;
-
-    background-position: 50% 50%;
-    background-size: 5000px calc(103%);
-    background-blend-mode: darken, screen, normal, normal, normal;
+@mixin maas-p-strip--dark {
+  .p-takeover--dark {
+    background-blend-mode: multiply, multiply, normal, normal;
+    background-color: #111;
+    background-image: linear-gradient(to bottom left, rgba(216, 216, 216, 0.54) 0, rgba(216, 216, 216, 0.54) 49.9%, transparent 50%), linear-gradient(to bottom right, rgba(228, 228, 228, 0.54) 0, rgba(228, 228, 228, 0.54) 49.9%, transparent 50%), linear-gradient(to top left, #fff 0%, #fff 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(201deg, #333 0%, #262626 46%, #111 90%);
+    color: #fff;
+    background-position: top right, top left, right bottom -1px, left top;
     background-repeat: no-repeat;
-  }
+    background-size: 74% 99.83%, 68% 91%, 103.8% 20.26%, 100% 99.8%;
+    margin: 0;
+    padding-bottom: 11rem;
+    padding-top: 6rem;
+}
 }

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -1,13 +1,13 @@
 @mixin maas-p-strip--dark {
-  $color-suru-grey-1: rgba(216, 216, 216, 0.54);
-  $color-suru-grey-2: rgba(228, 228, 228, 0.54);
+  $color-suru-grey-1: rgba(216, 216, 216, .54);
+  $color-suru-grey-2: rgba(228, 228, 228, .54);
   $color-suru-grey-3: #333;
   $color-suru-grey-4: #262626;
   $color-suru-grey-5: #171717;
   $color-suru-grey-6: #181818;
   $color-suru-grey-7: #2d2d2d;
   $color-suru-grey-8: #383838;
-  $color-suru-grey-9: #2E2E2E;
+  $color-suru-grey-9: #2e2e2e;
   $color-suru-grey-10: #393939;
 
   .p-takeover--dark {
@@ -16,24 +16,24 @@
     background-image: linear-gradient(to bottom left,
       $color-suru-grey-1 0,
       $color-suru-grey-1 49.9%, transparent 50%),
-      linear-gradient(to bottom right,
+    linear-gradient(to bottom right,
       $color-suru-grey-2 0,
       $color-suru-grey-2 49.9%,
       transparent 50%),
-      linear-gradient(to top left,
+    linear-gradient(to top left,
       $color-x-light 0%,
       $color-x-light 49.3%,
       transparent 50%,
       transparent 100%),
-      linear-gradient(201deg,
+    linear-gradient(201deg,
       $color-suru-grey-3 0%,
       $color-suru-grey-4 46%,
       $color-dark 90%
     );
-    color: $color-x-light;
     background-position: top right, top left, right bottom -1px, left top;
     background-repeat: no-repeat;
-    background-size: 74% 99.83%, 68% 91%, 103.8% 20.26%, 100% 99.8%;
+    background-size: 74% 99.83%, 68% 91%, 103.8% 2.26%, 100% 99.8%;
+    color: $color-x-light;
     margin: 0;
     padding-bottom: 11rem;
     padding-top: 6rem;

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -1,43 +1,40 @@
 @mixin maas-p-strip-slanted {
-  $assets-path: 'https://assets.ubuntu.com/v1/';
-  $horizontal-edge-padding: $spv-outer--regular-scaleable;
-  $slanted-edge-padding: $horizontal-edge-padding; // coloured area takes half the rectangle surface area; to visually compensate, we multiply it by 2
-
   [class^='p-strip'].is-slanted {
-    background-image: url('#{$assets-path}127c8ba7-hero-bg-maas-2.svg');
-    background-position: 50% 47%;
+    background-color: #111;
     overflow: hidden;
     position: relative;
 
     @media (max-width: $breakpoint-large) {
-      background-size: cover;
-      padding: $spv-outer--regular-scaleable 0 $slanted-edge-padding;
+      padding: $spv-outer--deep-scaleable * 0.5 0 $spv-outer--deep-scaleable;
     }
     @media (min-width: $breakpoint-large) {
-      background-size: 5000px 667px; // actual svg size
-      padding: $spv-outer--regular-scaleable 0 $slanted-edge-padding;
+      padding: $spv-outer--deep-scaleable 0 $spv-outer--deep-scaleable * 2;
     }
 
-    &::after {
-      $bleed: -3px; // stretch outside to compensate for aliasing; otherwise edge of image underneath becomes visible as you resize
-      background-position: 100% 100%;
-      background-repeat: no-repeat;
-      bottom: $bleed;
-      content: '';
-      left: $bleed;
-      pointer-events: none;
-      position: absolute;
-      right: $bleed;
-      top: $bleed;
-      z-index: 1;
+    // Generate golden ratio based angles in degrees and gradient color stops in percentages
+    $golden-ratio-angles: 3, 8;
+    $golden-ratio-percentages: 1, 2, 3;
 
-      @media only screen and (max-width: $breakpoint-large) {
-        background-size: auto $slanted-edge-padding;
-      }
-
-      @media only screen and (min-width: $breakpoint-large) {
-        background-size: 100%;
-      }
+    @each $i in $golden-ratio-angles {
+      --gr#{$i}: #{100/pow(1.618,$i)}deg;
     }
+
+    @each $i in $golden-ratio-percentages {
+      --g#{$i}: #{100/pow(1.618,$i)}%;
+    }
+
+    // magic number to make line go through center of video playback button
+    --g2a: 47.2%;
+
+    background-image:
+      linear-gradient(calc(-1 * var(--gr8)), #fff var(--g3), rgba(255, 255, 255, 0) calc(var(--g3) * 1.003)),
+      linear-gradient(var(--gr3), rgba(31, 31, 31, 0.5) var(--g2), rgba(255, 255, 255, 0) var(--g2)),
+      linear-gradient(calc(var(--gr3) * -1), rgba(31, 31, 31, 0.5) var(--g2), rgba(255, 255, 255, 0) var(--g1)),
+      linear-gradient(calc(var(--gr3) * -1), rgba(31, 31, 31, 0.5) var(--g2a), rgba(255, 255, 255, 0) var(--g2a)),
+      linear-gradient(calc(var(--gr3) * -1), rgba(31, 31, 31, 0.5) var(--g2), rgba(255, 255, 255, 0) var(--g2))
+    ;
+
+    background-position: 50% 50%, var(--g2) 50%, 50% 50%, 50% 50%, var(--g2) 50%;
+    background-size: 5000px calc(103%);
   }
 }

--- a/static/sass/_patterns_strips.scss
+++ b/static/sass/_patterns_strips.scss
@@ -26,7 +26,7 @@
     // magic numbers to make lines go through center of video playback button
     --g2a: 46.5%;
     --g2b: 55.5%;
-    --g2p: 26%;
+    --g2p: 31%;
 
     background-image:
       linear-gradient(calc(var(--gr7) * 1), #f0f0f000 var(--g2p), #f0f0f0ff var(--g2p)), //light grey overlap

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -26,7 +26,7 @@ $increase-font-size-on-larger-screens: false;
 @include maas-p-takeunders;
 @include maas-p-tables;
 @include maas-p-contact-modal;
-@include maas-p-strip-slanted;
+@include maas-p-strip--dark;
 @include maas-l-docs;
 @include maas-p-sidenav;
 

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -6,7 +6,7 @@
 
 
 {% block content %}
-<section class="p-strip--image is-dark is-deep" style="overflow: hidden; background-color: #333; background-image:url('https://assets.ubuntu.com/v1/6e4b2b20-MAAS-hero-background.png')">
+<section class="p-strip--image is-dark p-takeover--no-overlays">
   <div class="row">
     <div class="col-8">
       <h1 itemprop="description">Contact Canonical</h1>

--- a/templates/docs/api.html
+++ b/templates/docs/api.html
@@ -22,7 +22,7 @@
     </aside>
     <main class="l-docs-content" id="main-content">
       <div class="p-strip is-shallow">
-        <div class="l-docs-row">
+        <div class="l-docs-row row">
             <h1 id="maas-api">MAAS API</h1>
             <p>Restful MAAS API.</p>
             <p>This is the documentation for the API that lets you control and query MAAS. The API is &quot;Restful&quot;, which means that you access it through normal HTTP requests.</p>

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -23,18 +23,18 @@
     </aside>
     <main class="l-docs-content" id="main-content">
       <div class="p-strip--light is-shallow l-docs-title">
-        <div class="l-docs-row">
+        <div class="l-docs-row row">
           <h1 class="u-no-margin--bottom l-docs-title__heading">{{ document.title }}</h1>
         </div>
       </div>
 
       <div class="p-strip is-shallow">
-        <div class="l-docs-row">
+        <div class="l-docs-row row">
           {{ document.body_html | safe }}
         </div>
       </div>
       <div class="p-strip is-shallow u-no-padding--top">
-        <div class="l-docs-row">
+        <div class="l-docs-row row">
           <div class="p-notification--information">
             <p class="p-notification__response">
               Last updated {{ document.updated }}.

--- a/templates/how-it-works.html
+++ b/templates/how-it-works.html
@@ -5,7 +5,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/16tkFyk2W-AkoJYeE9qoFjwzHBlH4diazN9tlqRsV3XA/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--image is-dark is-deep" style="overflow: hidden; background-color: #333; background-image:url('https://assets.ubuntu.com/v1/6e4b2b20-MAAS-hero-background.png')">
+<section class="p-strip--image is-dark p-takeover--no-overlays">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-6">
         <h1>How it works</h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,9 @@
     <div class="col-6">
       <h1>Very fast <br class="u-hide--small u-hide--medium" />server provisioning</h1>
       <p>Self-service, remote installation of Windows, CentOS, ESXi and Ubuntu on real servers turns your data center into a bare-metal cloud.</p>
-      <p class="u-sv1">Welcome to metal-as-a-service.</p>
+      <p>Welcome to metal-as-a-service.</p>
       <a aria-label="Find out how to install MAAS" href="/install" class="p-button--positive" itemprop="url">Install MAAS</a>
+      <br>
     </div>
     <div class="col-6 p-hero-video u-hide--small">
       <a href="#" aria-label="Watch the MAAS video on YouTube" class="p-hero-video__link" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Video', 'eventAction' : 'Play', 'eventLabel' : 'Watch the MAAS video' });">

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,8 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--dark is-slanted">
+
+<section class="p-takeover--dark">
   <div class="row">
     <div class="col-6">
       <h1>Very fast <br class="u-hide--small u-hide--medium" />server provisioning</h1>

--- a/templates/install.html
+++ b/templates/install.html
@@ -6,7 +6,7 @@
 
 
 {% block content %}
-  <section class="p-strip--image is-dark is-deep" style="overflow: hidden; background-color: #333; background-image:url('https://assets.ubuntu.com/v1/6e4b2b20-MAAS-hero-background.png')">
+  <section class="p-strip--image is-dark is-deep p-takeover--no-overlays">
         <div class="row">
             <div class="col-7 suffix-one">
                 <h1>Install MAAS</h1>

--- a/templates/tour.html
+++ b/templates/tour.html
@@ -6,7 +6,7 @@
 
 
 {% block content %}
-<section class="p-strip--image is-dark is-deep" style="overflow: hidden; background-color: #333; background-image:url('https://assets.ubuntu.com/v1/6e4b2b20-MAAS-hero-background.png')">
+<section class="p-strip--image is-dark p-takeover--no-overlays">
     <div class="row">
       <h4>MAAS 2.6</h4>
       <h1 class="u-no-margin--bottom" itemprop="description">Overview and new features<br class="u-hide--small u-hide--medium" /> in the latest release</h1>


### PR DESCRIPTION
## Done

- Include a slant
- base padding on the vanilla deep strip, doubling the bottom padding
- create up to three intersecting lines to adhere to suru guidelines
- express angles and gradient stops as golden ratio fibonacci sequences, so it is easy to prototype without arbitrary values

## QA

- ./run
- QA homepage on different screen sizes

## Issue / Card

## Screenshots
![image](https://user-images.githubusercontent.com/2741678/70340439-b44eda80-1848-11ea-934a-2a99b6497220.png)
