### PR TITLE
Move blog feed from server to client

### DIFF
--- a/static/js/latest-news.js
+++ b/static/js/latest-news.js
@@ -1,0 +1,136 @@
+(function() {
+  function _formatDate(date) {
+    const parsedDate = new Date(date);
+    const monthNames = [
+      "January", "February", "March",
+      "April", "May", "June", "July",
+      "August", "September", "October",
+      "November", "December"
+    ];
+    return parsedDate.getDate() +
+      ' ' +
+      monthNames[parsedDate.getMonth()] +
+      ' ' +
+      parsedDate.getFullYear();
+  }
+
+  function _articleDiv(article, articleTemplateSelector, options) {
+    const articleFragment = _getTemplate(articleTemplateSelector);
+    const time = articleFragment.querySelector('.article-time');
+    const link = articleFragment.querySelector('.article-link');
+    const title = articleFragment.querySelector('.article-title');
+
+    let hostname = options.hostname || 'ubuntu.com';
+
+    let url = '';
+
+    if (options.hostname) {
+      url = 'https://' + options.hostname;
+    }
+
+    if (time) {
+      time.datetime = article.date;
+      time.innerText = _formatDate(article.date);
+    }
+
+    if (link) {
+      link.href = url + '/blog/' + article.slug;
+      if (options.gtmEventLabel) {
+        link.onclick = function() {
+          dataLayer.push(
+            {
+              'event': 'GAEvent',
+              'eventCategory': 'blog',
+              'eventAction': options.gtmEventLabel + ' news link',
+              'eventLabel': article.slug
+            }
+          );
+        }
+      }
+    }
+
+    if (title) {
+      title.innerHTML = article.title.rendered;
+    }
+
+    return articleFragment
+  }
+
+  function _getTemplate(selector) {
+    const template = document.querySelector(selector);
+    let fragment;
+
+    if ('content' in template) {
+      fragment = document.importNode(template.content, true);
+    } else {
+      fragment = document.createDocumentFragment();
+
+      for (let i = 0; i < template.childNodes.length; i++) {
+        fragment.appendChild(template.childNodes[i].cloneNode(true));
+      }
+    }
+
+    return fragment;
+  }
+
+  function _latestArticlesCallback(options) {
+    return function(event) {
+      const articlesContainer = document.querySelector(options.articlesContainerSelector);
+
+      // Clear out latest news container
+      while (articlesContainer.hasChildNodes()) {
+        articlesContainer.removeChild(articlesContainer.lastChild);
+      }
+
+      const data = JSON.parse(event.target.responseText);
+
+      if ("spotlightContainerSelector" in options) {
+        const spotlightContainer = document.querySelector(options.spotlightContainerSelector);
+        const latestPinned = data.latest_pinned_articles[0];
+
+        if (latestPinned) {
+          spotlightContainer.appendChild(_articleDiv(latestPinned, options.spotlightTemplateSelector, options));
+        }
+      }
+
+      if (data.latest_articles) {
+        data.latest_articles.forEach(function(article) {
+          articlesContainer.appendChild(_articleDiv(article, options.articleTemplateSelector, options));
+        });
+      }
+    };
+  }
+
+  function fetchLatestNews(options) {
+    let url = "https://ubuntu.com/blog/latest-news";
+    let params = [];
+
+    if (options.limit) {
+      params.push("limit=" + options.limit);
+    }
+
+    if (options.tagId) {
+      params.push("tag-id=" + options.tagId);
+    }
+
+    if (options.groupId) {
+      params.push("group-id=" + options.groupId);
+    }
+
+    if (params.length) {
+      url += "?" + params.join('&')
+    }
+
+    const oReq = new XMLHttpRequest();
+    oReq.addEventListener(
+      "load",
+      _latestArticlesCallback(options)
+    );
+    oReq.open("GET", url);
+    oReq.send();
+  }
+
+  if (typeof (window.fetchLatestNews) == "undefined") {
+    window.fetchLatestNews = fetchLatestNews
+  }
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -699,26 +699,32 @@
       <h2 class="p-link--external p-muted-heading">
         <a class="p-link--soft" aria-label="External link to find more MAAS news from the Ubuntu blog" href="https://ubuntu.com/blog/topics/maas">The latest MAAS news</a>
       </h2>
+      <div id="latest-articles" class="row">
+        <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
+      </div>
     </div>
   </div>
-  <div class="row">
-    <div id="insights-cloud-feed" class="p-divider">
-      {% with insights_feed = get_rss_feed("https://admin.insights.ubuntu.com/tag/maas/feed", limit=3) %}
-        {% if insights_feed %}
-          {% for item in insights_feed %}
-            <article class="col-4 p-divider__block">
-              <h3 class="p-heading--four"><a href="{{ item.link.replace('admin.insights.ubuntu.com', 'ubuntu.com/blog') }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'maas.io homepage news link', 'eventLabel' : '{{ item.title|escape }}', 'eventValue' : '{{ item.link }}' });">{{ item.title }}</a></h3>
-              <footer>
-                <time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime.strftime('%d %B %y') }}</time>
-              </footer>
-            </article>
-          {% endfor %}
-        {% else %}
-          <p>Feed failed to load. If you have time, please <a href="https://github.com/canonical-websites/maas.io/issues/new">file an issue</a>.</p>
-        {% endif %}
-      {% endwith %}
+
+  <template style="display:none" id="articles-template">
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four"><a class="article-link article-title"></a></h3>
+      <footer>
+        <time pubdate datetime="POST_UPDATED" class="article-time"></time>
+      </footer>
     </div>
-  </div>
-</section>
+  </template>
+
+  <script src="{{ versioned_static('js/latest-news.js') }}"></script>
+  <script>
+    fetchLatestNews(
+      {
+        articlesContainerSelector: "#latest-articles",
+        articleTemplateSelector: "#articles-template",
+        hostname: "ubuntu.com",
+        gtmEventLabel: "ubuntu.com homepage",
+        tagId: 1304 // MAAS tag ID
+      }
+    )
+  </script>
 
 {% endblock %}


### PR DESCRIPTION
## Done

Replace server side blog feed with client side blog feed

## QA

- Go to the homepage and scroll down to the "Latest MAAS news" section
- See that the blog posts are there and have the MAAS tag (e.g. click through to them - you'll have to replace the hostname with ubuntu.com to see the post)

## Issue / Card

Fixes #400 