### PR TITLE
Move edit links to top of maas.io/docs pages

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -27,12 +27,7 @@
           <h1 class="u-no-margin--bottom l-docs-title__heading">{{ document.title }}</h1>
         </div>
       </div>
-
-      <div class="p-strip is-shallow">
-        <div class="l-docs-row">
-          {{ document.body_html | safe }}
-        </div>
-      </div>
+      
       <div class="p-strip is-shallow u-no-padding--top">
         <div class="l-docs-row">
           <div class="p-notification--information">
@@ -41,6 +36,12 @@
               <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
             </p>
           </div>
+        </div>
+      </div>
+
+      <div class="p-strip is-shallow">
+        <div class="l-docs-row">
+          {{ document.body_html | safe }}
         </div>
       </div>
     </main>


### PR DESCRIPTION
At Adam's request/approval, I have moved (I think) the "Last Update" status and edit link to the top of the page, above the body text.

## Done

[List of work items including drive-bys]

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
