### PR TITLE
Float the improve the doc link on the docs

### DIFF
--- a/static/sass/_layout_docs.scss
+++ b/static/sass/_layout_docs.scss
@@ -47,7 +47,6 @@
   .l-docs-content {
     flex: 5;
     margin-top: 0;
-    overflow: hidden;
 
     @media only screen and (max-width: $breakpoint-navigation-threshold) {
       flex: auto;
@@ -67,9 +66,15 @@
     @extend .row;
     margin-left: inherit;
     padding: 0 $sp-xxx-large;
+    padding-bottom: 0;
 
     @media only screen and (max-width: $breakpoint-navigation-threshold) {
       padding-left: $sph-outer--large;
     }
+  }
+
+  .u-sticky--bottom {
+    bottom: 0;
+    position: sticky;
   }
 }

--- a/static/sass/_layout_docs.scss
+++ b/static/sass/_layout_docs.scss
@@ -66,7 +66,6 @@
     @extend .row;
     margin-left: inherit;
     padding: 0 $sp-xxx-large;
-    padding-bottom: 0;
 
     @media only screen and (max-width: $breakpoint-navigation-threshold) {
       padding-left: $sph-outer--large;
@@ -74,7 +73,9 @@
   }
 
   .u-sticky--bottom {
-    bottom: 0;
-    position: sticky;
+    @media only screen and (min-width: $breakpoint-navigation-threshold) {
+      bottom: 0;
+      position: sticky;
+    }
   }
 }

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -33,11 +33,17 @@
           {{ document.body_html | safe }}
         </div>
       </div>
-      <div class="p-strip is-shallow u-no-padding--top">
+
+      <div class="p-strip is-shallow u-no-padding--bottom">
+        <div class="l-docs-row row">
+          <hr />
+          <i>Last updated {{ document.updated }}.</i>
+        </div>
+      </div>
+      <div class="p-strip is-shallow u-no-padding--bottom u-sticky--bottom">
         <div class="l-docs-row row">
           <div class="p-notification--information">
             <p class="p-notification__response">
-              Last updated {{ document.updated }}.
               <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
             </p>
           </div>


### PR DESCRIPTION
## Done
Float the improve the doc link on the docs

## QA
- Go to /docs/web-ui
- See that the notification to improve the document is sticky to the bottom of the screen.
- Scroll down to the bottom of the page and see the notification unsticks
- Check the last updated content is visible at the bottom of the document
- Check a few pages all work as expected
- Check on small screens the notification does not stick 
