### PR TITLE
Change link in footer

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -28,7 +28,7 @@
                     <a class="p-link--external" href="https://askubuntu.com/questions/tagged/maas">Ask Ubuntu</a>
                 </li>
                 <li class="p-list__item">
-                    <a class="p-link--external" href="http://webchat.freenode.net/?channels=maas">Chat with MAAS on freenode</a>
+                    <a href="https://discourse.maas.io/">Discourse</a>
                 </li>
                 <li class="p-list__item">
                     <a class="p-link--external" href="https://lists.ubuntu.com/mailman/listinfo/maas-devel">Join the mailing list</a>


### PR DESCRIPTION


## Done

Changed link from "Chat on freenode" to "Discourse"

## QA

Check if footer no longer has "Chat with MAAS on freenode" link.
Check if "Discourse" link leads to discourse.maas.io

## Issue / Card

Fixes #427 

