### PR TITLE
Use multi-stage builds with Ubuntu Focal

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,10 @@
 cache.sqlite
 README.md
 HACKING.md
+renovate.json
+LICENSE.txt
+Dockerfile
+tests
 
 # The run script isn't needed
 run
@@ -19,6 +23,4 @@ run
 .env.local
 
 # Node is only needed for building, not running
-package.json
 node_modules
-yarn.lock

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "copy-3rd-party-js": "mkdir -p static/js/modules/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/modules/global-nav",
     "watch": "node-sass --include-path node_modules --source-map true --watch static/sass --output static/css",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
-    "build": "node-sass --include-path node_modules static/sass --output static/css --output-style compressed && yarn run copy-3rd-party-js"
+    "build-css": "node-sass --include-path node_modules static/sass --output static/css --output-style compressed",
+    "build-js": "yarn run copy-3rd-party-js",
+    "build": "yarn run build-css && yarn run build-js"
   },
   "author": "Canonical webteam",
   "license": "LGPL v3",


### PR DESCRIPTION
## Done

Added multi stage build and move ubuntu image to focal.

## QA

- `DOCKER_BUILDKIT=1 docker build -t maas.io:focal .`
- `docker run -ti -p "8006:80" maas.io:focal`
- Browse the site and make sure everything works
