### PR TITLE
Bump discourse docs version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 talisker[gunicorn]==0.15.0
-canonicalwebteam.discourse-docs==0.6.5
+canonicalwebteam.discourse-docs==0.10.3
 canonicalwebteam.flask_base==0.3.3
 canonicalwebteam.http==1.0.1
 canonicalwebteam.templatefinder==0.2.4

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -31,13 +31,13 @@ app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 doc_parser = DocParser(
     api=DiscourseAPI(base_url="https://discourse.maas.io/"),
     index_topic_id=25,
+    category_id=5,
     url_prefix="/docs",
 )
 if app.debug:
     doc_parser.api.session.adapters["https://"].timeout = 99
 discourse_docs = DiscourseDocs(
     parser=doc_parser,
-    category_id=5,
     document_template="docs/document.html",
     url_prefix="/docs",
 )


### PR DESCRIPTION
~~Once https://github.com/canonical-web-and-design/canonicalwebteam.discourse-docs/pull/31 is merged then QA this by having fun on docs.~~

# Summary

Upgrade discourse docs version.

# QA 

- `./run`
- Go on `/docs`
- Make sure the docs still work.