### PR TITLE
Use British spelling for the word “centre”

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="col-6">
       <h1>Very fast <br class="u-hide--small u-hide--medium" />server provisioning</h1>
-      <p>Self-service, remote installation of Windows, CentOS, ESXi and Ubuntu on real servers turns your data center into a bare-metal cloud.</p>
+      <p>Self-service, remote installation of Windows, CentOS, ESXi and Ubuntu on real servers turns your data centre into a bare-metal cloud.</p>
       <p>Welcome to metal-as-a-service.</p>
       <a aria-label="Find out how to install MAAS" href="/install" class="p-button--positive" itemprop="url">Install MAAS</a>
       <br>
@@ -316,7 +316,7 @@
       <h2>Real servers,<br>self-service</h2>
     </div>
     <div class="col-6">
-      <p>You run the data center, but your customers decide what they want to do with the hardware. They love the cloud experience, but it’s more efficient for you to own the hardware.</p>
+      <p>You run the data centre, but your customers decide what they want to do with the hardware. They love the cloud experience, but it’s more efficient for you to own the hardware.</p>
       <p>MAAS provides super-fast self-service provisioning of Windows, Ubuntu, CentOS and ESXi.</p>
       <p>
         <a href="https://pages.ubuntu.com/eBook-MAAS.html?source=maas_page&medium=Banner&campaign=MAAS_ebook&_ga=2.22106171.1851959601.1510602087-405342743.1460033629" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about server provisioning with MAAS' });">Learn more about server provisioning with MAAS</a>
@@ -393,7 +393,7 @@
         <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/36fe873f-MAAS-Real+world+icon-Scale.svg" style="padding-bottom: 0.8rem;" />
         <div class="p-heading-icon-block__copy-block">
           <h5 class="u-no-margin--bottom">Scale</h5>
-          <p class="p-muted-heading u-no-margin--bottom">Data center</p>
+          <p class="p-muted-heading u-no-margin--bottom">Data centre</p>
         </div>
       </div>
     </div>
@@ -437,7 +437,7 @@
   <div class="row">
     <div class="col-6">
       <h4>Detection and configuration</h4>
-      <p>The most error-prone part of data center operations is the network.</p>
+      <p>The most error-prone part of data centre operations is the network.</p>
       <p>MAAS enables rapid convergence on a correct network configuration &mdash; for every server, in every rack. All NICs are detected and inventoried when a machine is enlisted in MAAS.</p>
       <p>Discover the topology of the network &mdash; which NIC is plugged into which port on which switch. MAAS tests access to specific VLANs from each NIC.</p>
       <p>Network bonds and VLANs can be configured too. Set all significant network operating properties through MAAS &mdash; and then validate that configuration with ephemeral machine booting and testing.</p>
@@ -465,7 +465,7 @@
 
 <section class="p-strip">
   <div class="row">
-    <h2>Your future data center, available now</h2>
+    <h2>Your future data centre, available now</h2>
   </div>
   <div class="row">
     <div class="col-6">
@@ -475,7 +475,7 @@
       <p>Take devops to bare metal for apps like big data, kubernetes, analytics, machine learning, private cloud, OpenStack, PAAS and HPC. Specialists love MAAS.</p>
     </div>
     <div class="col-6">
-      <h4>Open source software-defined data center</h4>
+      <h4>Open source software-defined data centre</h4>
       <p>MAAS is an open source SDDC solution used by telcos, financial institutions, media companies and supercomputer admins to take care of all the low-level details. PXE, IPMI, ILO and all the custom protocols needed for diverse vendor hardware support come together in one clean REST API with Python bindings for easy integration and automation. It includes full IPAM capabilities, providing a central database and REST API for all network addressing and naming information.</p>
       <h4>KVM MicroCloud for Edge Computing</h4>
       <p>MAAS offers the ability to create lean, on-demand KVM-based micro-clouds. This capability extends to fine-grained control over KVM storage and networking configuration, thereby accelerating deployment of applications in any environment constrained by physical footprint or requiring dedicated VM-based workloads.</p>


### PR DESCRIPTION
## Done

Changed the spelling of “center” to “centre” per the Canonical style guide

## QA

Scour the index page to ensure that no instances of the American spelling of “centre” remain. (I used grep, so it should be OK.)

## Issue / Card

Fixes #415