### PR TITLE
Build release banner for 2.7.

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -14,6 +14,8 @@
   <body class="{% block page_class %}{% endblock %}">
     {% include "includes/header.html" %}
 
+    {% include "includes/banner.html" %}
+
     <div class="u-no-margin--top {% block content_class %}{% endblock %}" id="main-content">
       {% block content %}{% endblock %}
     </div>

--- a/templates/includes/banner.html
+++ b/templates/includes/banner.html
@@ -1,0 +1,9 @@
+<section class="p-strip--light is-shallow">
+  <div class="row">
+    <div class="col-12">
+      <strong>MAAS 2.7 is released!</strong>
+      Check out <a href="/docs/release-notes">the release notes</a>. Follow
+      <a href="/install">the install instructions</a> to get the version.
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done
- Built a banner for the 2.7 release, similar to the one on snapcraft.

## QA
- Check the banner shows up on every page.
- Check the links go to where you would expect.

## Issue / Card
Fixes canonical-web-and-design/MAAS-squad#1830

## Screenshots
![Screenshot_2020-02-19 Metal as a Service MAAS](https://user-images.githubusercontent.com/25733845/74824196-373fe700-5308-11ea-866e-107c02ef3587.png)

