### PR TITLE
Update support information in the footer

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -31,13 +31,7 @@
       <h3 class="p-heading--four">Need help?</h3>
       <ul class="p-list">
         <li class="p-list__item">
-          <a class="p-link--external" href="https://askubuntu.com/questions/tagged/maas">Ask Ubuntu</a>
-        </li>
-        <li class="p-list__item">
           <a href="https://discourse.maas.io/">Discourse</a>
-        </li>
-        <li class="p-list__item">
-          <a class="p-link--external" href="https://lists.ubuntu.com/mailman/listinfo/maas-devel">Join the mailing list</a>
         </li>
         <li class="p-list__item">
           <a class="js-invoke-modal" href="/contact-us">Commercial support</a>
@@ -59,16 +53,16 @@
   </div>
   <nav class="row">
     <div class="has-cookie">
-      <p>&copy; {{ now("%Y") }} Canonical Ltd. <a href="http://www.ubuntu.com">Ubuntu</a> and <a href="http://www.canonical.com">Canonical</a> are registered trademarks of Canonical Ltd.</p>
+      <p>&copy; {{ now("%Y") }} Canonical Ltd. <a href="https://www.ubuntu.com">Ubuntu</a> and <a href="https://www.canonical.com">Canonical</a> are registered trademarks of Canonical Ltd.</p>
       <ul class="p-inline-list--middot">
         <li class="p-inline-list__item">
-          <a href="http://www.ubuntu.com/legal"><small>Legal information</small></a>
+          <a href="https://www.ubuntu.com/legal"><small>Legal information</small></a>
         </li>
         <li class="p-inline-list__item">
           <a href="https://github.com/canonical-web-and-design/maas.io/issues/new/"><small>Report a bug on this site</small></a>
         </li>
       </ul>
-      <span class="u-off-screen"><a href="#">Got to the top of the page</a></span>
+      <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
     </div>
   </nav>
 </footer>


### PR DESCRIPTION

## Done
- Ask Ubuntu and maas-devel ML deprecated in favour of Discourse
- (drive-by) https://-ify the links
- (drive-by) Fix typo in "Go to the top of the page"

## QA

* Verify there's no links to askubuntu or maas-devel ML in the footer
* Clicking links should avoid a redirect to https:// versions of ubuntu.com and canonical.com
