### PR TITLE
Update packer-maas to 1.0.3

### DIFF
--- a/templates/vmware-images.html
+++ b/templates/vmware-images.html
@@ -56,7 +56,7 @@
             <input type="hidden" name="formid" class="mktoField" value="3392">
             <input type="hidden" name="formVid" class="mktoField" value="3392">
             <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
-            <input type="hidden" name="download_asset_url" class="mktoField" value="https://assets.ubuntu.com/v1/f8e9fa9d-packer-maas-1.0.2.tar.xz">
+            <input type="hidden" name="download_asset_url" class="mktoField" value="https://github.com/canonical/packer-maas/archive/1.0.3.tar.gz">
             <input type="hidden" name="returnURL" value="">
             <input type="hidden" name="retURL" value="">
           </form>
@@ -69,7 +69,7 @@
       <h2>Thank you for registering</h2>
       <p>
         <strong>Your download should start automatically</strong>.<br>
-        Problems? <a href="https://assets.ubuntu.com/v1/f8e9fa9d-packer-maas-1.0.2.tar.xz">Download 'ESXi.iso.packer.template'</a>.
+        Problems? <a href="https://github.com/canonical/packer-maas/archive/1.0.3.tar.gz">Download 'ESXi.iso.packer.template'</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

* Updated URL for download of vmware template to 1.0.3 (latest release, another one due soon)

## QA
* Verified that download served from github

## Issue / Card

## Screenshots
