### PR TITLE
Update to gevent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2
 defaults: &defaults
   docker:
     - image: canonicalwebteam/dev
+      environment:
+        SECRET_KEY: local_development_fake_key
 
 jobs:
   test-site:

--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn webapp.app:app --bind $1 --worker-class sync --workers 2 --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-talisker[gunicorn]==0.16.0
+canonicalwebteam.flask_base==0.6.0
 canonicalwebteam.discourse-docs==0.11.1
-canonicalwebteam.flask_base==0.4.3
 canonicalwebteam.http==1.0.1
 canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.0.0
-flask==1.1.1
 feedparser==5.2.1


### PR DESCRIPTION
## Done

- Update talisker v0.18.0
- Update to use gevent

## QA

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag maas.io  .`
-  `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key maas.io`
- http://0.0.0.0:8006/
- Play around with the site and make sure it works well 