### PR TITLE
Remove filled MAAS role

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -70,7 +70,6 @@
 <script src="/static/js/modules/global-nav/global-nav.js"></script>
 <script>
   canonicalGlobalNav.createNav({
-    hiring: 'https://boards.greenhouse.io/canonical/jobs/2032752',
     maxWidth: '72rem',
   });
 </script>


### PR DESCRIPTION
## Done
Remove filled MAAS role

## QA
- Check the global nav in the demo
- See there is no "We're hiring" link in the global nav
