### PR TITLE
Switch to templatefinder v1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask_base==0.6.0
 canonicalwebteam.discourse-docs==0.11.1
 canonicalwebteam.http==1.0.3
-canonicalwebteam.templatefinder==0.2.5
+canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.1.0
 feedparser==5.2.1


### PR DESCRIPTION
0.2.5 doesn't exist any more.

QA
--

`dotrun`, go to the homepage, click "Contact us", check the modal works.