### PR TITLE
Fix Python dependencies issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # Install python and import python dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-lib2to3 python3-pkg-resources
+RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-setuptools python3-lib2to3 python3-pkg-resources
 ENV PATH="/root/.local/bin:${PATH}"
 
 # Copy python dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask_base==0.6.0
 canonicalwebteam.discourse-docs==0.11.1
 canonicalwebteam.http==1.0.3
-canonicalwebteam.templatefinder==0.2.5
+canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.1.0
 feedparser==5.2.1


### PR DESCRIPTION
## Done

Fix Python dependencies issue

## QA

- Pull the branch
- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag test .`
- `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key test`
