### PR TITLE
Remove 2.7 channel from install

### DIFF
--- a/templates/install.html
+++ b/templates/install.html
@@ -43,7 +43,7 @@
                 </h3>
                 <div class="p-stepped-list__content">
                   <div class="p-code-copyable">
-                      <input class="p-code-copyable__input" value="sudo snap install maas --channel=2.7" readonly="readonly">
+                      <input class="p-code-copyable__input" value="sudo snap install maas" readonly="readonly">
                       <button class="p-code-copyable__action">Copy to clipboard</button>
                   </div>
                 </div>


### PR DESCRIPTION
As per copy doc

## Done

* [install] Remove `--channel=2.7` from `snap install` instructions

## QA

* Load `/install` search page for 2.7

## Issue / Card

## Screenshots
