### PR TITLE
Restore install button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ bzr-repo/
 .DS_store
 
 .webcache
+
+.venv
+.dotrun.json

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
       <p>Self-service, remote installation of Windows, CentOS, ESXi and Ubuntu on real servers turns your data centre into a bare metal cloud.</p>
       <p>Welcome to metal-as-a-service.</p>
       <p style="display: flex;">
-        <a aria-label="Find out how to install MAAS" href="/contact-us" class="js-invoke-modal p-button--positive" itemprop="url">Move to MAAS today</a>
+        <a aria-label="Find out how to install MAAS" href="/install" class="p-button--positive" itemprop="url">Install MAAS</a>
         <span class="u-hide--small" style="position: relative; top: .4rem; margin-right: 1rem;">or</span>
         <a class="u-hide--small" href="https://snapcraft.io/maas"><img src="https://assets.ubuntu.com/v1/24140745-snap-store-badge-light-en.svg" alt="Get MAAS from the Snap store" style="height: 37px" /></a>
       </p>


### PR DESCRIPTION
## Done

- Revert the install button change on the homepage: https://github.com/canonical-web-and-design/maas.io/pull/499/commits/3c3e7ad84b47bc2930fbf219bb9985817212e60f#diff-fb5aa1cd1261d08d02db6f7dc314d9abL22-R22.

## QA

- Visit the homepage.
- Check that the green button in the "Very fast server provisioning for your data centre" section reads "Install MAAS" and links to /install

## Issue / Card

Fixes: https://github.com/canonical-web-and-design/maas.io/issues/505