### PR TITLE
Fix links from the tour to docs

### DIFF
--- a/templates/tour.html
+++ b/templates/tour.html
@@ -28,7 +28,7 @@
                 <h3>Graphical overview of your KVM host’s resources</h3>
                 <p>MAAS shows your KVM pod’s CPU cores and RAM, as well as the free space in storage pools.</p>
                 <p class="u-sv2">Manage and visualise overcommit ratios.</p>
-                <p><a href="https://docs.maas.io/2.5/en/manage-pods-webui#add-a-kvm-host"
+                <p><a href="https://maas.io/docs/add-a-vm-host"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'KVM' });"
                       class="p-link--external"
                       aria-label="External link to KVM in MAAS">Learn more about KVM in MAAS</a>
@@ -73,7 +73,7 @@
                 <h3>Unattended server discovery</h3>
                 <p><abbr title="Preboot eXecution Environment">PXE</abbr> boot your servers and containers and they will be automatically discovered and enlisted in MAAS.</p>
                 <p class="u-sv2"><abbr title="Intelligent Platform Management Interface">IPMI</abbr> enabled machines work seamlessly with MAAS.</p>
-                <p><a href="https://docs.maas.io/en/nodes-add"
+                <p><a href="https://maas.io/docs/add-machines"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' });"
                       class="p-link--external"
                       aria-label="External link to adding nodes page on MAAS documentation">Learn more about adding new nodes to MAAS</a>
@@ -92,7 +92,7 @@
                     <li>Accessible <abbr title="Virtual Local Area Network">VLAN</abbr>s</li>
                     <li>Attached switch fabrics</li>
                 </ul>
-                <p><a href="https://docs.maas.io/en/installconfig-networking"
+                <p><a href="https://maas.io/docs/networking"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
                       class="p-link--external"
                       aria-label="External link to the configuring networking page on MAAS documentation">Find out more about MAAS networking</a>
@@ -105,18 +105,18 @@
                     </a>
                 </div>
                 <h3>Simple device discovery</h3>
-                <p>MAAS can discover new <a href="https://docs.maas.io/en/installconfig-network-dev-discovery" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" class="p-link--external" aria-label="External link to device discovery page on MAAS documentation">devices</a> and <a href="https://docs.maas.io/en/installconfig-networking" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" class="p-link--external" aria-label="External link to install and config networking on MAAS documentation">network interfaces</a>:</p>
+                <p>MAAS can discover new <a href="https://maas.io/docs/network-discovery" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" class="p-link--external" aria-label="External link to device discovery page on MAAS documentation">devices and network interfaces</a>:</p>
                 <ul>
                     <li>Passively</li>
                     <li>On-demand</li>
                     <li>Periodically</li>
                 </ul>
                 <p>
-                    <a href="https://docs.maas.io/en/installconfig-network-dev-discovery"
+                    <a href="https://maas.io/docs/network-discovery"
                        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' });
                                 dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about device discovery and subnet mapping' });"
                        class="p-link--external"
-                       aria-label="External link to MAAS release notes page on MAAS documentation">Learn more about device discovery and subnet mapping</a>
+                       aria-label="External link to the configuring networking page on MAAS documentation">Learn more about device discovery and subnet mapping</a>
                 </p>
             </div>
         </div>
@@ -151,10 +151,10 @@
                     <li>Assign to physical zones</li>
                 </ul>
                 <p>
-                    <a href="https://docs.maas.io/en/intro-concepts#node-actions"
+                    <a href="https://maas.io/docs/machine-overview#heading--machine-life-cycle"
                         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });"
                         class="p-link--external"
-                        aria-label="External link to node actions page on MAAS documentation">Learn more about the node actions</a>
+                        aria-label="External link to machine lifecycle page on MAAS documentation">Learn more about the node actions</a>
                 </p>
             </div>
             <div class="col-6 p-divider__block">
@@ -173,7 +173,7 @@
                 </ul>
                 <p>Import, update or sync the images or connect to an onsite mirror to work offline.</p>
                 <p id="image-info"><small>* Images other than Ubuntu and CentOS require an <a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });" class="p-link--external" aria-label="External link to the Ubuntu Advantage page on ubuntu dot com">Ubuntu Advantage</a> licence</small> </p>
-                <p class="u-sv2"><a href="https://docs.maas.io/en/installconfig-images" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' });" class="p-link--external" aria-label="External link to the install config images page on MAAS documentation">Learn more about images</a></p>
+                <p class="u-sv2"><a href="https://maas.io/docs/images" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' });" class="p-link--external" aria-label="External link to the install config images page on MAAS documentation">Learn more about images</a></p>
             </div>
         </div>
     </div>
@@ -191,7 +191,7 @@
                     <li>Choose the OS and architecture</li>
                     <li>Press 'deploy'</li>
                 </ol>
-                <p><a href="https://docs.maas.io/en/nodes-deploy" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });" class="p-link--external" aria-label="External link to the install and config page of node deployment on MAAS documentation">Learn more about deployment</a></p>
+                <p><a href="https://maas.io/docs/deploy-nodes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });" class="p-link--external" aria-label="External link to the install and config page of node deployment on MAAS documentation">Learn more about deployment</a></p>
             </div>
             <div class="col-6 p-divider__block">
                 <div class="u-sv2">
@@ -242,7 +242,7 @@
                 <p>Access all historical testing data to discover trends of component metrics and failures.</p>
             </div>
         </div>
-        <p><a href="https://docs.maas.io/en/nodes-hw-testing?_ga=2.235290241.1856071436.1506441807-405342743.1460033629" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Keep an eye on your hardware feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about hardware testing' });" class="p-link--external" aria-label="External link to hardware testing on MAAS documentation">Learn more about hardware testing</a></p>
+        <p><a href="https://maas.io/docs/hardware-testing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Keep an eye on your hardware feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about hardware testing' });" class="p-link--external" aria-label="External link to hardware testing on MAAS documentation">Learn more about hardware testing</a></p>
     </div>
 </section>
 
@@ -272,7 +272,7 @@
                 <li>Virtual bridges</li>
                 <li>Static routes and more&hellip;</li>
             </ul>
-            <p><a href="https://docs.maas.io/en/nodes-commission#post-commission-configuration" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" class="p-link--external" aria-label="External link to the install config and commission nodes page on MAAS documentation">Learn more about interfaces</a></p>
+            <p><a href="https://maas.io/docs/commission-nodes#heading--post-commission-configuration" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" class="p-link--external" aria-label="External link to the install config and commission nodes page on MAAS documentation">Learn more about interfaces</a></p>
         </div>
     </div>
 </section>
@@ -296,7 +296,7 @@
                 <li><abbr title="Redundant Array of Independent Disks">RAID</abbr></li>
                 <li><abbr title="Logical Volume Management">LVM</abbr></li>
             </ul>
-            <p><a href="https://docs.maas.io/en/installconfig-storage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' });" class="p-link--external" aria-label="External link to install and configure storage on MAAS documentation">Learn more about storage</a></p>
+            <p><a href="https://maas.io/docs/storage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' });" class="p-link--external" aria-label="External link to install and configure storage on MAAS documentation">Learn more about storage</a></p>
         </div>
     </div>
 </section>
@@ -317,7 +317,7 @@
                 <li>Boot your machines from the network</li>
                 <li>Receive <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> requests relayed from remote networks</li>
             </ul>
-            <p><a href="https://docs.maas.io/en/installconfig-network-dhcp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about DHCP in MAAS' });" class="p-link--external u-sv2" aria-label="External link to install and configure network dhcp page on MAAS documentation">Learn more about <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> in MAAS</a></p>
+            <p><a href="https://maas.io/docs/dhcp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about DHCP in MAAS' });" class="p-link--external u-sv2" aria-label="External link to install and configure network dhcp page on MAAS documentation">Learn more about <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> in MAAS</a></p>
         </div>
         <div class="col-6">
             <h4>With full <abbr title="Domain name system">DNS</abbr> management you can</h4>
@@ -337,19 +337,19 @@
     </div>
     <div class="row">
         <ul class="col-4">
-            <li><abbr title="Internet Protocol version 4">IPv4</abbr> and <a href="https://docs.maas.io/en/installconfig-network-ipv6" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network Internet Protocol version 6 on MAAS documentation"><abbr title="Internet Protocol version 6">IPv6</abbr></a></li>
-            <li><a href="https://docs.maas.io/en/installconfig-network-subnet-management" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network subnet management on MAAS documentation">Subnets</a></li>
-            <li><a href="https://docs.maas.io/en/intro-concepts#vlans" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about virtual local area networks on MAAS documentation"><abbr title="Virtual local area network">VLAN</abbr></a></li>
+            <li><abbr title="Internet Protocol version 4">IPv4</abbr> and <a href="https://maas.io/docs/ipv6" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network Internet Protocol version 6 on MAAS documentation"><abbr title="Internet Protocol version 6">IPv6</abbr></a></li>
+            <li><a href="https://maas.io/docs/subnet-management" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network subnet management on MAAS documentation">Subnets</a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--vlans" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about virtual local area networks on MAAS documentation"><abbr title="Virtual local area network">VLAN</abbr></a></li>
         </ul>
         <ul class="col-4">
-            <li><a href="https://docs.maas.io/en/intro-concepts#fabrics" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about fabrics on MAAS documentation">Fabrics</a></li>
-            <li><a href="https://docs.maas.io/en/intro-concepts#spaces" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about spaces on MAAS documentation">Spaces</a></li>
-            <li><a href="https://docs.maas.io/en/installconfig-network-ntp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network ntp on MAAS documentation"><abbr title="Network Time Protocol">NTP</abbr></a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--fabrics" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about fabrics on MAAS documentation">Fabrics</a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--spaces" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about spaces on MAAS documentation">Spaces</a></li>
+            <li><a href="https://maas.io/docs/ntp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network ntp on MAAS documentation"><abbr title="Network Time Protocol">NTP</abbr></a></li>
         </ul>
         <ul class="col-4">
-            <li><a href="https://docs.maas.io/en/installconfig-network-ssl" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure secure sockets layer on MAAS documentation"><abbr title="Secure sockets layer">SSL</abbr></a></li>
-            <li><a href="https://docs.maas.io/en/installconfig-network-stp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure spanning tree protocol on MAAS documentation"><abbr title="Spanning tree protocol">STP</abbr></a></li>
-            <li><a href="https://docs.maas.io/en/installconfig-network-proxy" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network proxy on MAAS documentation">Proxy</a></li>
+            <li><a href="https://maas.io/docs/ssl" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure secure sockets layer on MAAS documentation"><abbr title="Secure sockets layer">SSL</abbr></a></li>
+            <li><a href="https://maas.io/docs/stp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure spanning tree protocol on MAAS documentation"><abbr title="Spanning tree protocol">STP</abbr></a></li>
+            <li><a href="https://maas.io/docs/proxy" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network proxy on MAAS documentation">Proxy</a></li>
         </ul>
     </div>
 </section>
@@ -370,14 +370,14 @@
                     }}
                 </div>
                 <div class="col-3">
-                    <h3 class="u-no-margin--bottom"><a class="p-heading--four p-link--inverted" href="https://docs.maas.io/en/manage-cli" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" aria-label="External link to manage command line interface page on MAAS documentation">See MAAS CLI on how to get started with the&nbsp;CLI&nbsp;&rsaquo;</a></h3>
+                    <h3 class="u-no-margin--bottom"><a class="p-heading--four p-link--inverted" href="https://maas.io/docs/maas-cli" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" aria-label="External link to manage command line interface page on MAAS documentation">See MAAS CLI on how to get started with the&nbsp;CLI&nbsp;&rsaquo;</a></h3>
                 </div>
             </div>
         </div>
         <div class="col-6 p-takeunder is-dark" style="background-color: #666;">
             <div class="row u-equal-height">
                 <div class="col-3 u-vertically-center">
-                    <h3><a class="p-heading--four p-link--inverted" href="https://docs.maas.io/en/api" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" aria-label="External link to application programming interface page on MAAS documentation">See the API documentation to automate and extend&nbsp;MAAS&nbsp;&rsaquo;</a></h3>
+                    <h3><a class="p-heading--four p-link--inverted" href="https://maas.io/docs/api" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" aria-label="External link to application programming interface page on MAAS documentation">See the API documentation to automate and extend&nbsp;MAAS&nbsp;&rsaquo;</a></h3>
                 </div>
                 <div class="col-3 u-align--center u-hide--small">
                     {{

--- a/templates/tour.html
+++ b/templates/tour.html
@@ -30,8 +30,7 @@
                 <p class="u-sv2">Manage and visualise overcommit ratios.</p>
                 <p><a href="https://maas.io/docs/add-a-vm-host"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'KVM' });"
-                      class="p-link--external"
-                      aria-label="External link to KVM in MAAS">Learn more about KVM in MAAS</a>
+                      aria-label="Link to KVM in MAAS">Learn more about KVM in MAAS</a>
                 </p>
             </div>
             <div class="col-4 p-divider__block">
@@ -75,8 +74,7 @@
                 <p class="u-sv2"><abbr title="Intelligent Platform Management Interface">IPMI</abbr> enabled machines work seamlessly with MAAS.</p>
                 <p><a href="https://maas.io/docs/add-machines"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' });"
-                      class="p-link--external"
-                      aria-label="External link to adding nodes page on MAAS documentation">Learn more about adding new nodes to MAAS</a>
+                      aria-label="Link to adding nodes page on MAAS documentation">Learn more about adding new nodes to MAAS</a>
                 </p>
             </div>
             <div class="col-4 p-divider__block">
@@ -94,8 +92,7 @@
                 </ul>
                 <p><a href="https://maas.io/docs/networking"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
-                      class="p-link--external"
-                      aria-label="External link to the configuring networking page on MAAS documentation">Find out more about MAAS networking</a>
+                      aria-label="Link to the configuring networking page on MAAS documentation">Find out more about MAAS networking</a>
                 </p>
             </div>
             <div class="col-4 p-divider__block">
@@ -105,7 +102,7 @@
                     </a>
                 </div>
                 <h3>Simple device discovery</h3>
-                <p>MAAS can discover new <a href="https://maas.io/docs/network-discovery" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" class="p-link--external" aria-label="External link to device discovery page on MAAS documentation">devices and network interfaces</a>:</p>
+                <p>MAAS can discover new <a href="https://maas.io/docs/network-discovery" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" aria-label="Link to device discovery page on MAAS documentation">devices and network interfaces</a>:</p>
                 <ul>
                     <li>Passively</li>
                     <li>On-demand</li>
@@ -115,8 +112,7 @@
                     <a href="https://maas.io/docs/network-discovery"
                        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' });
                                 dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about device discovery and subnet mapping' });"
-                       class="p-link--external"
-                       aria-label="External link to the configuring networking page on MAAS documentation">Learn more about device discovery and subnet mapping</a>
+                       aria-label="Link to the configuring networking page on MAAS documentation">Learn more about device discovery and subnet mapping</a>
                 </p>
             </div>
         </div>
@@ -153,8 +149,7 @@
                 <p>
                     <a href="https://maas.io/docs/machine-overview#heading--machine-life-cycle"
                         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });"
-                        class="p-link--external"
-                        aria-label="External link to machine lifecycle page on MAAS documentation">Learn more about the node actions</a>
+                        aria-label="Link to machine lifecycle page on MAAS documentation">Learn more about the node actions</a>
                 </p>
             </div>
             <div class="col-6 p-divider__block">
@@ -172,8 +167,8 @@
                     <li>RHEL</li>
                 </ul>
                 <p>Import, update or sync the images or connect to an onsite mirror to work offline.</p>
-                <p id="image-info"><small>* Images other than Ubuntu and CentOS require an <a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });" class="p-link--external" aria-label="External link to the Ubuntu Advantage page on ubuntu dot com">Ubuntu Advantage</a> licence</small> </p>
-                <p class="u-sv2"><a href="https://maas.io/docs/images" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' });" class="p-link--external" aria-label="External link to the install config images page on MAAS documentation">Learn more about images</a></p>
+                <p id="image-info"><small>* Images other than Ubuntu and CentOS require an <a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });" aria-label="Link to the Ubuntu Advantage page on ubuntu dot com">Ubuntu Advantage</a> licence</small> </p>
+                <p class="u-sv2"><a href="https://maas.io/docs/images" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' });" aria-label="Link to the install config images page on MAAS documentation">Learn more about images</a></p>
             </div>
         </div>
     </div>
@@ -191,7 +186,7 @@
                     <li>Choose the OS and architecture</li>
                     <li>Press 'deploy'</li>
                 </ol>
-                <p><a href="https://maas.io/docs/deploy-nodes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });" class="p-link--external" aria-label="External link to the install and config page of node deployment on MAAS documentation">Learn more about deployment</a></p>
+                <p><a href="https://maas.io/docs/deploy-nodes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });" aria-label="Link to the install and config page of node deployment on MAAS documentation">Learn more about deployment</a></p>
             </div>
             <div class="col-6 p-divider__block">
                 <div class="u-sv2">
@@ -242,7 +237,7 @@
                 <p>Access all historical testing data to discover trends of component metrics and failures.</p>
             </div>
         </div>
-        <p><a href="https://maas.io/docs/hardware-testing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Keep an eye on your hardware feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about hardware testing' });" class="p-link--external" aria-label="External link to hardware testing on MAAS documentation">Learn more about hardware testing</a></p>
+        <p><a href="https://maas.io/docs/hardware-testing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Keep an eye on your hardware feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about hardware testing' });" aria-label="Link to hardware testing on MAAS documentation">Learn more about hardware testing</a></p>
     </div>
 </section>
 
@@ -272,7 +267,7 @@
                 <li>Virtual bridges</li>
                 <li>Static routes and more&hellip;</li>
             </ul>
-            <p><a href="https://maas.io/docs/commission-nodes#heading--post-commission-configuration" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" class="p-link--external" aria-label="External link to the install config and commission nodes page on MAAS documentation">Learn more about interfaces</a></p>
+            <p><a href="https://maas.io/docs/commission-nodes#heading--post-commission-configuration" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" aria-label="Link to the install config and commission nodes page on MAAS documentation">Learn more about interfaces</a></p>
         </div>
     </div>
 </section>
@@ -296,7 +291,7 @@
                 <li><abbr title="Redundant Array of Independent Disks">RAID</abbr></li>
                 <li><abbr title="Logical Volume Management">LVM</abbr></li>
             </ul>
-            <p><a href="https://maas.io/docs/storage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' });" class="p-link--external" aria-label="External link to install and configure storage on MAAS documentation">Learn more about storage</a></p>
+            <p><a href="https://maas.io/docs/storage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' });" aria-label="Link to install and configure storage on MAAS documentation">Learn more about storage</a></p>
         </div>
     </div>
 </section>
@@ -317,7 +312,7 @@
                 <li>Boot your machines from the network</li>
                 <li>Receive <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> requests relayed from remote networks</li>
             </ul>
-            <p><a href="https://maas.io/docs/dhcp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about DHCP in MAAS' });" class="p-link--external u-sv2" aria-label="External link to install and configure network dhcp page on MAAS documentation">Learn more about <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> in MAAS</a></p>
+            <p><a href="https://maas.io/docs/dhcp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about DHCP in MAAS' });" class="u-sv2" aria-label="Link to install and configure network dhcp page on MAAS documentation">Learn more about <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> in MAAS</a></p>
         </div>
         <div class="col-6">
             <h4>With full <abbr title="Domain name system">DNS</abbr> management you can</h4>
@@ -337,19 +332,19 @@
     </div>
     <div class="row">
         <ul class="col-4">
-            <li><abbr title="Internet Protocol version 4">IPv4</abbr> and <a href="https://maas.io/docs/ipv6" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network Internet Protocol version 6 on MAAS documentation"><abbr title="Internet Protocol version 6">IPv6</abbr></a></li>
-            <li><a href="https://maas.io/docs/subnet-management" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network subnet management on MAAS documentation">Subnets</a></li>
-            <li><a href="https://maas.io/docs/concepts-and-terms#heading--vlans" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about virtual local area networks on MAAS documentation"><abbr title="Virtual local area network">VLAN</abbr></a></li>
+            <li><abbr title="Internet Protocol version 4">IPv4</abbr> and <a href="https://maas.io/docs/ipv6" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network Internet Protocol version 6 on MAAS documentation"><abbr title="Internet Protocol version 6">IPv6</abbr></a></li>
+            <li><a href="https://maas.io/docs/subnet-management" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network subnet management on MAAS documentation">Subnets</a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--vlans" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about virtual local area networks on MAAS documentation"><abbr title="Virtual local area network">VLAN</abbr></a></li>
         </ul>
         <ul class="col-4">
-            <li><a href="https://maas.io/docs/concepts-and-terms#heading--fabrics" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about fabrics on MAAS documentation">Fabrics</a></li>
-            <li><a href="https://maas.io/docs/concepts-and-terms#heading--spaces" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to intro concepts about spaces on MAAS documentation">Spaces</a></li>
-            <li><a href="https://maas.io/docs/ntp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network ntp on MAAS documentation"><abbr title="Network Time Protocol">NTP</abbr></a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--fabrics" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about fabrics on MAAS documentation">Fabrics</a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--spaces" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about spaces on MAAS documentation">Spaces</a></li>
+            <li><a href="https://maas.io/docs/ntp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network ntp on MAAS documentation"><abbr title="Network Time Protocol">NTP</abbr></a></li>
         </ul>
         <ul class="col-4">
-            <li><a href="https://maas.io/docs/ssl" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure secure sockets layer on MAAS documentation"><abbr title="Secure sockets layer">SSL</abbr></a></li>
-            <li><a href="https://maas.io/docs/stp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure spanning tree protocol on MAAS documentation"><abbr title="Spanning tree protocol">STP</abbr></a></li>
-            <li><a href="https://maas.io/docs/proxy" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });" class="p-link--external" aria-label="External link to install and configure network proxy on MAAS documentation">Proxy</a></li>
+            <li><a href="https://maas.io/docs/ssl" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure secure sockets layer on MAAS documentation"><abbr title="Secure sockets layer">SSL</abbr></a></li>
+            <li><a href="https://maas.io/docs/stp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure spanning tree protocol on MAAS documentation"><abbr title="Spanning tree protocol">STP</abbr></a></li>
+            <li><a href="https://maas.io/docs/proxy" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network proxy on MAAS documentation">Proxy</a></li>
         </ul>
     </div>
 </section>
@@ -370,14 +365,14 @@
                     }}
                 </div>
                 <div class="col-3">
-                    <h3 class="u-no-margin--bottom"><a class="p-heading--four p-link--inverted" href="https://maas.io/docs/maas-cli" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" aria-label="External link to manage command line interface page on MAAS documentation">See MAAS CLI on how to get started with the&nbsp;CLI&nbsp;&rsaquo;</a></h3>
+                    <h3 class="u-no-margin--bottom"><a class="p-heading--four p-link--inverted" href="https://maas.io/docs/maas-cli" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" aria-label="Link to manage command line interface page on MAAS documentation">See MAAS CLI on how to get started with the&nbsp;CLI&nbsp;&rsaquo;</a></h3>
                 </div>
             </div>
         </div>
         <div class="col-6 p-takeunder is-dark" style="background-color: #666;">
             <div class="row u-equal-height">
                 <div class="col-3 u-vertically-center">
-                    <h3><a class="p-heading--four p-link--inverted" href="https://maas.io/docs/api" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" aria-label="External link to application programming interface page on MAAS documentation">See the API documentation to automate and extend&nbsp;MAAS&nbsp;&rsaquo;</a></h3>
+                    <h3><a class="p-heading--four p-link--inverted" href="https://maas.io/docs/api" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" aria-label="Link to application programming interface page on MAAS documentation">See the API documentation to automate and extend&nbsp;MAAS&nbsp;&rsaquo;</a></h3>
                 </div>
                 <div class="col-3 u-align--center u-hide--small">
                     {{

--- a/templates/tour.html
+++ b/templates/tour.html
@@ -30,7 +30,7 @@
                 <p class="u-sv2">Manage and visualise overcommit ratios.</p>
                 <p><a href="https://maas.io/docs/add-a-vm-host"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'KVM' });"
-                      aria-label="Link to KVM in MAAS">Learn more about KVM in MAAS</a>
+                      aria-label="Link to KVM in MAAS">Learn more about KVM in MAAS&nbsp;&rsaquo;</a>
                 </p>
             </div>
             <div class="col-4 p-divider__block">
@@ -74,7 +74,7 @@
                 <p class="u-sv2"><abbr title="Intelligent Platform Management Interface">IPMI</abbr> enabled machines work seamlessly with MAAS.</p>
                 <p><a href="https://maas.io/docs/add-machines"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' });"
-                      aria-label="Link to adding nodes page on MAAS documentation">Learn more about adding new nodes to MAAS</a>
+                      aria-label="Link to adding nodes page on MAAS documentation">Learn more about adding new nodes to MAAS&nbsp;&rsaquo;</a>
                 </p>
             </div>
             <div class="col-4 p-divider__block">
@@ -92,7 +92,7 @@
                 </ul>
                 <p><a href="https://maas.io/docs/networking"
                       onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"
-                      aria-label="Link to the configuring networking page on MAAS documentation">Find out more about MAAS networking</a>
+                      aria-label="Link to the configuring networking page on MAAS documentation">Find out more about MAAS networking&nbsp;&rsaquo;</a>
                 </p>
             </div>
             <div class="col-4 p-divider__block">
@@ -102,7 +102,7 @@
                     </a>
                 </div>
                 <h3>Simple device discovery</h3>
-                <p>MAAS can discover new <a href="https://maas.io/docs/network-discovery" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" aria-label="Link to device discovery page on MAAS documentation">devices and network interfaces</a>:</p>
+                <p>MAAS can discover new <a href="https://maas.io/docs/network-discovery" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" aria-label="Link to device discovery page on MAAS documentation">devices and network interfaces&nbsp;&rsaquo;</a>:</p>
                 <ul>
                     <li>Passively</li>
                     <li>On-demand</li>
@@ -112,7 +112,7 @@
                     <a href="https://maas.io/docs/network-discovery"
                        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' });
                                 dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about device discovery and subnet mapping' });"
-                       aria-label="Link to the configuring networking page on MAAS documentation">Learn more about device discovery and subnet mapping</a>
+                       aria-label="Link to the configuring networking page on MAAS documentation">Learn more about device discovery and subnet mapping&nbsp;&rsaquo;</a>
                 </p>
             </div>
         </div>
@@ -149,7 +149,7 @@
                 <p>
                     <a href="https://maas.io/docs/machine-overview#heading--machine-life-cycle"
                         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });"
-                        aria-label="Link to machine lifecycle page on MAAS documentation">Learn more about the node actions</a>
+                        aria-label="Link to machine lifecycle page on MAAS documentation">Learn more about the node actions&nbsp;&rsaquo;</a>
                 </p>
             </div>
             <div class="col-6 p-divider__block">
@@ -167,8 +167,8 @@
                     <li>RHEL</li>
                 </ul>
                 <p>Import, update or sync the images or connect to an onsite mirror to work offline.</p>
-                <p id="image-info"><small>* Images other than Ubuntu and CentOS require an <a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });" aria-label="Link to the Ubuntu Advantage page on ubuntu dot com">Ubuntu Advantage</a> licence</small> </p>
-                <p class="u-sv2"><a href="https://maas.io/docs/images" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' });" aria-label="Link to the install config images page on MAAS documentation">Learn more about images</a></p>
+                <p id="image-info"><small>* Images other than Ubuntu and CentOS require an <a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });" class="p-link--external" aria-label="External link to the Ubuntu Advantage page on ubuntu dot com">Ubuntu Advantage</a> licence</small> </p>
+                <p class="u-sv2"><a href="https://maas.io/docs/images" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' });" aria-label="Link to the install config images page on MAAS documentation">Learn more about images&nbsp;&rsaquo;</a></p>
             </div>
         </div>
     </div>
@@ -186,7 +186,7 @@
                     <li>Choose the OS and architecture</li>
                     <li>Press 'deploy'</li>
                 </ol>
-                <p><a href="https://maas.io/docs/deploy-nodes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });" aria-label="Link to the install and config page of node deployment on MAAS documentation">Learn more about deployment</a></p>
+                <p><a href="https://maas.io/docs/deploy-nodes" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });" aria-label="Link to the install and config page of node deployment on MAAS documentation">Learn more about deployment&nbsp;&rsaquo;</a></p>
             </div>
             <div class="col-6 p-divider__block">
                 <div class="u-sv2">
@@ -237,7 +237,7 @@
                 <p>Access all historical testing data to discover trends of component metrics and failures.</p>
             </div>
         </div>
-        <p><a href="https://maas.io/docs/hardware-testing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Keep an eye on your hardware feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about hardware testing' });" aria-label="Link to hardware testing on MAAS documentation">Learn more about hardware testing</a></p>
+        <p><a href="https://maas.io/docs/hardware-testing" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Keep an eye on your hardware feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about hardware testing' });" aria-label="Link to hardware testing on MAAS documentation">Learn more about hardware testing&nbsp;&rsaquo;</a></p>
     </div>
 </section>
 
@@ -267,7 +267,7 @@
                 <li>Virtual bridges</li>
                 <li>Static routes and more&hellip;</li>
             </ul>
-            <p><a href="https://maas.io/docs/commission-nodes#heading--post-commission-configuration" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" aria-label="Link to the install config and commission nodes page on MAAS documentation">Learn more about interfaces</a></p>
+            <p><a href="https://maas.io/docs/commission-nodes#heading--post-commission-configuration" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about interfaces' });" aria-label="Link to the install config and commission nodes page on MAAS documentation">Learn more about interfaces&nbsp;&rsaquo;</a></p>
         </div>
     </div>
 </section>
@@ -291,7 +291,7 @@
                 <li><abbr title="Redundant Array of Independent Disks">RAID</abbr></li>
                 <li><abbr title="Logical Volume Management">LVM</abbr></li>
             </ul>
-            <p><a href="https://maas.io/docs/storage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' });" aria-label="Link to install and configure storage on MAAS documentation">Learn more about storage</a></p>
+            <p><a href="https://maas.io/docs/storage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' });" aria-label="Link to install and configure storage on MAAS documentation">Learn more about storage&nbsp;&rsaquo;</a></p>
         </div>
     </div>
 </section>
@@ -312,7 +312,7 @@
                 <li>Boot your machines from the network</li>
                 <li>Receive <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> requests relayed from remote networks</li>
             </ul>
-            <p><a href="https://maas.io/docs/dhcp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about DHCP in MAAS' });" class="u-sv2" aria-label="Link to install and configure network dhcp page on MAAS documentation">Learn more about <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> in MAAS</a></p>
+            <p><a href="https://maas.io/docs/dhcp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about DHCP in MAAS' });" class="u-sv2" aria-label="Link to install and configure network dhcp page on MAAS documentation">Learn more about <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> in MAAS&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-6">
             <h4>With full <abbr title="Domain name system">DNS</abbr> management you can</h4>
@@ -332,19 +332,19 @@
     </div>
     <div class="row">
         <ul class="col-4">
-            <li><abbr title="Internet Protocol version 4">IPv4</abbr> and <a href="https://maas.io/docs/ipv6" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network Internet Protocol version 6 on MAAS documentation"><abbr title="Internet Protocol version 6">IPv6</abbr></a></li>
-            <li><a href="https://maas.io/docs/subnet-management" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network subnet management on MAAS documentation">Subnets</a></li>
-            <li><a href="https://maas.io/docs/concepts-and-terms#heading--vlans" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about virtual local area networks on MAAS documentation"><abbr title="Virtual local area network">VLAN</abbr></a></li>
+            <li><abbr title="Internet Protocol version 4">IPv4</abbr> and <a href="https://maas.io/docs/ipv6" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network Internet Protocol version 6 on MAAS documentation"><abbr title="Internet Protocol version 6">IPv6</abbr>&nbsp;&rsaquo;</a></li>
+            <li><a href="https://maas.io/docs/subnet-management" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network subnet management on MAAS documentation">Subnets&nbsp;&rsaquo;</a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--vlans" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about virtual local area networks on MAAS documentation"><abbr title="Virtual local area network">VLAN</abbr>&nbsp;&rsaquo;</a></li>
         </ul>
         <ul class="col-4">
-            <li><a href="https://maas.io/docs/concepts-and-terms#heading--fabrics" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about fabrics on MAAS documentation">Fabrics</a></li>
-            <li><a href="https://maas.io/docs/concepts-and-terms#heading--spaces" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about spaces on MAAS documentation">Spaces</a></li>
-            <li><a href="https://maas.io/docs/ntp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network ntp on MAAS documentation"><abbr title="Network Time Protocol">NTP</abbr></a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--fabrics" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about fabrics on MAAS documentation">Fabrics&nbsp;&rsaquo;</a></li>
+            <li><a href="https://maas.io/docs/concepts-and-terms#heading--spaces" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to intro concepts about spaces on MAAS documentation">Spaces&nbsp;&rsaquo;</a></li>
+            <li><a href="https://maas.io/docs/ntp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network ntp on MAAS documentation"><abbr title="Network Time Protocol">NTP</abbr>&nbsp;&rsaquo;</a></li>
         </ul>
         <ul class="col-4">
-            <li><a href="https://maas.io/docs/ssl" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure secure sockets layer on MAAS documentation"><abbr title="Secure sockets layer">SSL</abbr></a></li>
-            <li><a href="https://maas.io/docs/stp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure spanning tree protocol on MAAS documentation"><abbr title="Spanning tree protocol">STP</abbr></a></li>
-            <li><a href="https://maas.io/docs/proxy" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network proxy on MAAS documentation">Proxy</a></li>
+            <li><a href="https://maas.io/docs/ssl" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure secure sockets layer on MAAS documentation"><abbr title="Secure sockets layer">SSL</abbr>&nbsp;&rsaquo;</a></li>
+            <li><a href="https://maas.io/docs/stp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure spanning tree protocol on MAAS documentation"><abbr title="Spanning tree protocol">STP</abbr>&nbsp;&rsaquo;</a></li>
+            <li><a href="https://maas.io/docs/proxy" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });"  aria-label="Link to install and configure network proxy on MAAS documentation">Proxy&nbsp;&rsaquo;</a></li>
         </ul>
     </div>
 </section>


### PR DESCRIPTION
## Done

* Updated docs links to point to https://maas.io/docs/ 
* Drive-by: remove 2.5 specific link, remove ga nonsense,

## QA

* Inspect all links on the /tour and verify none point to docs.maas.io

## Issue / Card

N/A

## Screenshots

![image](https://user-images.githubusercontent.com/246192/92576915-fa2a4a80-f281-11ea-9878-b8d97ed47bbe.png)
