### PR TITLE
Remove the copydoc meta tag from docs

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -8,7 +8,7 @@
     {% with css_file="css/main.css" %}
       {% include "includes/head.html" %}
     {% endwith %}
-    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B2sqJRO7vy3ZfnM0YTNyNUNJelVNRWktVjQ1dHJicnRPVkk4UW1CZ1owU2FOWEdGM0dxUnM{% endblock %}">
+    {% if self.meta_copydoc() %}<meta name="copydoc" content="{% block meta_copydoc %}{% endblock %}">{% endif %}
 
   </head>
   <body class="{% block page_class %}{% endblock %}">

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -3,6 +3,8 @@
 {% block page_class %}docs{% endblock %}
 {% block content_class %}l-docs-wrapper{% endblock %}
 {% block page_title %}| {{ document.title }} {% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
 
 {% block content %}
   <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -3,7 +3,6 @@
 {% block page_class %}docs{% endblock %}
 {% block content_class %}l-docs-wrapper{% endblock %}
 {% block page_title %}| {{ document.title }} {% endblock %}
-{% block meta_copydoc %}{% endblock meta_copydoc %}
 
 
 {% block content %}


### PR DESCRIPTION
## Done
Remove the copydoc meta tag from docs

## QA
- Go to /docs
- See the copydoc meta tag is blank
