### PR TITLE
Remove category hardcoded

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 PORT=8006
 FLASK_DEBUG=true
+DEVEL=True
 SECRET_KEY=insecure_dev_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask_base==0.6.1
+canonicalwebteam.flask_base==0.6.3
 canonicalwebteam.discourse-docs==1.0.0
 canonicalwebteam.http==1.0.3
 canonicalwebteam.templatefinder==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask_base==0.6.3
+canonicalwebteam.flask_base==0.6.4
 canonicalwebteam.discourse-docs==1.0.0
 canonicalwebteam.http==1.0.3
 canonicalwebteam.templatefinder==1.0.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -37,7 +37,6 @@ docs_discourse_api = DiscourseAPI(
 doc_parser = DocParser(
     api=docs_discourse_api,
     index_topic_id=25,
-    category_id=5,
     url_prefix="/docs",
 )
 if app.debug:


### PR DESCRIPTION
## Done

The hard coded category is not required.
This allows to make a lot of API requests in the category endpoint. There are 1327 topics so it takes a while to do all the requests since the pagination is ~50 topics.... This is required for a specific need not necessary in the maas docs case.

## QA

- dotrun
- http://0.0.0.0:8006/docs
- Have fun in the docs and make sure they still work
