### PR TITLE
Integrate cookie-policy v3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "ubuntu-maas",
   "description": "Static Django website blueprint",
   "scripts": {
-    "start": "yarn run build && yarn run serve",    
+    "start": "yarn run build && yarn run serve",
     "build": "yarn run build-css && yarn run build-js",
     "build-css": "node-sass --include-path node_modules static/sass --output static/css --output-style compressed",
     "build-js": "yarn run copy-3rd-party-js",
     "clean": "rm -rf node_modules yarn-error.log static/css *.log *.sqlite _site/ build/ .jekyll-metadata",
-    "copy-3rd-party-js": "yarn run copy-global-nav && yarn run copy-latest-news",
+    "copy-3rd-party-js": "yarn run copy-global-nav && yarn run copy-latest-news && yarn run copy-cookie-policy",
+    "copy-cookie-policy": "mkdir -p static/js/modules/cookie-policy && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules/cookie-policy",
     "copy-global-nav": "mkdir -p static/js/modules/global-nav && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/modules/global-nav",
     "copy-latest-news": "mkdir -p static/js/modules/latest-news && cp node_modules/@canonical/latest-news/dist/latest-news.js static/js/modules/latest-news",
     "lint-python": "flake8 --exclude '*env*,node_modules' && black --line-length 79 --check --exclude '(node_modules/.*|[^/]*env[0-9]?/.*)' .",
@@ -27,6 +28,7 @@
     "vanilla-framework": "2.19.1"
   },
   "dependencies": {
+    "@canonical/cookie-policy": "3.0.4",
     "@canonical/global-nav": "2.4.3",
     "@canonical/latest-news": "1.0.4"
   }

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -6,6 +6,9 @@ $increase-font-size-on-larger-screens: false;
 // import vanilla-brochure-theme
 @import 'vanilla-framework/scss/build';
 
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";
+
 // patterns
 @import
   'patterns_strips',

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -59,6 +59,9 @@
           <a href="https://www.ubuntu.com/legal"><small>Legal information</small></a>
         </li>
         <li class="p-inline-list__item">
+          <a class="p-footer__link js-revoke-cookie-manager" href=""><small>Manage your tracker settings</small></a>
+        </li>
+        <li class="p-inline-list__item">
           <a href="https://github.com/canonical-web-and-design/maas.io/issues/new/"><small>Report a bug on this site</small></a>
         </li>
       </ul>
@@ -68,9 +71,12 @@
 </footer>
 
 <script src="/static/js/modules/global-nav/global-nav.js"></script>
+<script src="/static/js/modules/cookie-policy/cookie-policy.js"></script>
 <script>
   canonicalGlobalNav.createNav({
     maxWidth: '72rem',
     hiring: 'https://canonical.com/careers/2313885',
   });
+
+  cpNs.cookiePolicy();
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,6 +191,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@canonical/cookie-policy@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.4.tgz#c2d6d990dc0993344a9bf5c244374e3f51fe34f1"
+  integrity sha512-pI65cRFh9xU2xo3d9R8ifGbQoH72tk3p8xh/4ANuj9kREeh9G/gcim/iHQS7IffSocHT9l6ZtUXBcQ12m/CBMw==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done
Integrate cookie-policy v3.0.4

## QA
- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8004/
- Check the cookie policy appears
- Check the manager opens and works
- Make a selection and the notification should disappear
- Scroll to the footer and click the Manage link in the footer
- See that manager appears again. 

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3272
