### PR TITLE
Update the MAAS release banner to be 2.9

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 <div class="p-strip--light is-shallow">
   <div class="row">
     <div>
-      <strong>MAAS 2.8 has been released</strong>, supporting LXD VM hosts, faster UI and many bug fixes. Find out <a href="/docs/release-notes">what&rsquo;s new in 2.8</a>. </div>
+      <strong>MAAS 2.9 has been released</strong>. Find out <a href="/docs/release-notes">what&rsquo;s new in 2.9</a>. </div>
   </div>
 </div>
 <section class="p-takeover--dark">


### PR DESCRIPTION
## Done
Update the MAAS release banner to be 2.9

## QA
- Load the demo
- Check the release banner
- Hit the link and check it goes to the right place

## Issue / Card
Fixes https://github.com/canonical-web-and-design/maas.io/issues/543

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/101616018-be308e00-3a06-11eb-9b67-7de06bd480b8.png)

