### PR TITLE
Remove 2.9 release announcement.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,12 +5,6 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip--light is-shallow">
-  <div class="row">
-    <div>
-      <strong>MAAS 2.9 has been released</strong>. Find out <a href="/docs/release-notes">what&rsquo;s new in 2.9</a>. </div>
-  </div>
-</div>
 <section class="p-takeover--dark">
   <div class="row">
     <div class="col-7">


### PR DESCRIPTION
-------

## Done

Removed 2.9 release announcement

## QA

Load the site, see there's no shout out for 2.9

## Issue / Card

## Screenshots
![Screenshot_2021-03-03 Metal as a Service MAAS](https://user-images.githubusercontent.com/246192/109827326-861a9f00-7c33-11eb-95a4-5bbc3b830080.png)
