### PR TITLE
Improve caching headers with flask-base 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask_base==0.7.3
+canonicalwebteam.flask_base==0.8.0
 canonicalwebteam.discourse-docs==1.0.1
 canonicalwebteam.http==1.0.3
 canonicalwebteam.templatefinder==1.0.0


### PR DESCRIPTION
Upgrade to [flask-base v0.8.0](https://github.com/canonical-web-and-design/canonicalwebteam.flask-base/pull/45) to benefit from the better default caching headers.

This should specifically improve the [slow performance of docs pages](https://github.com/canonical-web-and-design/maas.io/issues/559). Here's why:

It does take a while to generate the docs pages. We're not quite sure why this is as slow as it is, but it makes sense that it would take some time because it does have to make a few calls to Discourse. We should be able to mitigate this through caching.

At present, the page is cached for 5 minutes, and then will refresh in the background for a further minute. Unless we get a visit within that 6th minute, the next visitor will experience a slow response. It seems that the docs pages just don't get enough visits for this cache to remain fresh, so most visitors end up getting the slow response.

The new defaults extend this 1-minute window for background-refreshing the cache to 1 day. This should hopefully be sufficient.

Fixes https://github.com/canonical-web-and-design/maas.io/issues/559

QA
--

It's not easy to QA that this actually fixes the docs issue, as that's dependent on traffic levels. And the demo isn't even behind the content-cache, so it can't tell you much.

But you can inspect the headers and check they in theory should serve stale cache for a day:

``` bash
$ curl -sI https://maas-io-573.demos.haus/docs | grep cache-control
cache-control: max-age=60, stale-while-revalidate=86400, stale-if-error=300
```
