### PR TITLE
Add link to Ubuntu certified hardware

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,9 @@
   </div>
     <div class="row">
     <ul class="p-list row">
-          <li class="p-list__item is-ticked is-large col-4 p-heading--five u-no-margin--top">Works on all certified servers from any major vendor</li>
+          <li class="p-list__item is-ticked is-large col-4 p-heading--five u-no-margin--top">
+            <a href="https://ubuntu.com/certified?category=Server">Works on all Canonical certified servers</a>
+          </li>
           <li class="p-list__item is-ticked is-large col-4 p-heading--five u-no-margin--top">Discovers servers in racks, chassis and data centre networks</li>
           <li class="p-list__item is-ticked is-large col-4 p-heading--five u-no-margin--top">Supports major system BMCs and chassis controllers</li>
         </ul>


### PR DESCRIPTION
## Done

- Added a link to the Ubuntu certified hardware page

## QA

- Go to the homepage
- Scroll down to the "Deploy any OS on any hardware section"
- Check that the ticked list includes a link to the Ubuntu certified hardware page, as per the [copydoc](https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit#)

## Issue / Card

Fixes #596 

## Screenshots

![Screenshot 2021-08-10 at 09-53-37 Metal as a Service MAAS](https://user-images.githubusercontent.com/25733845/128788505-8e2b0a64-a4c9-4640-8a97-3e44daedf93d.png)
