### PR TITLE
Add Open Graph meta data to the head of the site

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr" itemscope itemtype="http://schema.org/Product">
+<html lang="en" dir="ltr" itemscope itemtype="http://schema.org/Product" prefix="og: http://ogp.me/ns#">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -23,3 +23,10 @@
 <meta name="twitter:title" content="Metal as a Service | MAAS">
 <meta name="twitter:description" content="MAAS (Metal as a Service) offers cloud style provisioning for physical servers. It is open source and free to use, with commercial support available from Canonical.">
 <meta name="twitter:image" content="https://assets.ubuntu.com/v1/6c4a1064-maas-twitter-logo.jpg">
+
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://maas.io/">
+<meta property="og:site_name" content="MAAS">
+<meta property="og:title" content="Metal as a Service | MAAS">
+<meta property="og:description" content="MAAS (Metal as a Service) offers cloud style provisioning for physical servers. It is open source and free to use, with commercial support available from Canonical.">
+<meta property="og:image" content="https://assets.ubuntu.com/v1/6c4a1064-maas-twitter-logo.jpg">

--- a/templates/index.html
+++ b/templates/index.html
@@ -432,7 +432,7 @@ document.addEventListener('DOMContentLoaded', function () {
     <div class="row">
       <div class="col-4">
         <div class="p-heading-icon-block">
-          <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/0ae9bd9c-MAAS-Real+world+icon-Flexibility.svg" style="padding: 1rem 1rem 1rem 0;" />
+          <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/0ae9bd9c-MAAS-Real+world+icon-Flexibility.svg" alt="" style="padding: 1rem 1rem 1rem 0;" />
           <div class="p-heading-icon-block__copy-block">
             <h5 class="u-no-margin--bottom">Flexibility</h5>
             <p class="p-muted-heading u-no-margin--bottom">Edge</p>
@@ -455,7 +455,7 @@ document.addEventListener('DOMContentLoaded', function () {
   <div class="row">
     <div class="col-4">
       <div class="p-heading-icon-block">
-        <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/89815b24-MAAS-Real+world+icon-Ease-of-use.svg" />
+        <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/89815b24-MAAS-Real+world+icon-Ease-of-use.svg" alt="" />
         <div class="p-heading-icon-block__copy-block">
           <h5 class="u-no-margin--bottom">Ease of use</h5>
           <p class="p-muted-heading u-no-margin--bottom">Small &amp; medium business</p>
@@ -473,7 +473,7 @@ document.addEventListener('DOMContentLoaded', function () {
   <div class="row">
     <div class="col-4">
       <div class="p-heading-icon-block">
-        <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/36fe873f-MAAS-Real+world+icon-Scale.svg" style="padding-bottom: 0.8rem;" />
+        <img class="p-heading-icon-block__icon" src="https://assets.ubuntu.com/v1/36fe873f-MAAS-Real+world+icon-Scale.svg" alt="" style="padding-bottom: 0.8rem;" />
         <div class="p-heading-icon-block__copy-block">
           <h5 class="u-no-margin--bottom">Scale</h5>
           <p class="p-muted-heading u-no-margin--bottom">Data centre</p>


### PR DESCRIPTION
## Done
- Add Open Graph meta data to the head of the site
- _Drive by_ Add alt tags to images missing them

## QA
- Go to https://www.opengraph.xyz/url/https%3A%2F%2Fmaas.io/
- Check the cards don't look great
- Go to https://www.opengraph.xyz/url/https%3A%2F%2Fmaas-io-602.demos.haus%2F/
- Check the image is coming through ok

## Issue / Card
Fixes https://github.com/canonical-web-and-design/maas.io/issues/601

## Screenshots
**Before**
![www opengraph xyz_url_https%3A%2F%2Fmaas io_](https://user-images.githubusercontent.com/1413534/130463136-80917613-0fd8-40bf-9af1-9d68acbb62d3.png)

**After**
![www opengraph xyz_url_https%3A%2F%2Fmaas io_ (1)](https://user-images.githubusercontent.com/1413534/130476141-ff441273-ea2e-42de-873d-8ffab132cbef.png)

