### PR TITLE
Revert /tour title to 2.7

### DIFF
--- a/templates/tour.html
+++ b/templates/tour.html
@@ -8,7 +8,7 @@
 {% block content %}
 <section class="p-strip--image is-dark p-takeover--no-overlays">
     <div class="row">
-      <h4>MAAS 2.9</h4>
+      <h4>MAAS 2.7</h4>
       <h1 class="u-no-margin--bottom" itemprop="description">Overview and new features<br class="u-hide--small u-hide--medium" /> in the latest release</h1>
     </div>
 </section>


### PR DESCRIPTION
## Done

Mistakely updated to 2.9 while the content was for 2.7.

## QA

See that title has been reverted

