### PR TITLE
Fix MAAS logo misalignement in Safari

### DIFF
--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a href="/" class="p-navigation__link">
-          <img src="https://assets.ubuntu.com/v1/e1bdea10-MAAS+White.svg" alt="" width="100" height="48">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/e1bdea10-MAAS+White.svg" alt="" width="100" height="48">
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>


### PR DESCRIPTION
## Done

fix maas logo misalignement in Safari

## Issue / Card

Fixes #647

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/7452681/144410260-602dc5d0-ba61-4987-85a7-cfb65354bdf8.png)

### After
![image](https://user-images.githubusercontent.com/7452681/144410276-71f9d258-7e38-46ed-a81f-7be0432d6dd2.png)

