### PR TITLE
remove latest news section

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -659,7 +659,7 @@ document.addEventListener('DOMContentLoaded', function () {
   </div>
 </section>
 
-<section class="p-strip u-no-padding--bottom">
+<section class="p-strip is-bordered u-no-padding--bottom">
   <div class="row">
     <div class="col-6">
       <h2>Enterprise support <br class="u-hide--small" />for MAAS</h2>
@@ -739,41 +739,6 @@ document.addEventListener('DOMContentLoaded', function () {
       </div>
     </div>
   </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-12">
-      <h3 class="p-muted-heading">
-        <a class="p-link--soft" aria-label="Link to find more MAAS news from the MAAS blog" href="/blog">The latest MAAS news</a>
-      </h3>
-      <div id="latest-articles" class="row">
-        <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
-      </div>
-    </div>
-  </div>
-
-  <template style="display:none" id="articles-template">
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four"><a class="article-link article-title"></a></h3>
-      <footer>
-        <time pubdate datetime="POST_UPDATED" class="article-time"></time>
-      </footer>
-    </div>
-  </template>
-
-  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
-  <script>
-    canonicalLatestNews.fetchLatestNews(
-      {
-        articlesContainerSelector: "#latest-articles",
-        articleTemplateSelector: "#articles-template",
-        hostname: "maas.io",
-        gtmEventLabel: "maas.io homepage",
-        tagId: 1304 // MAAS tag ID
-      }
-    )
-  </script>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
## Done

- remove latest news section
- add a border to the last section to separate from the footer (latest news was the last section displayed immediately before the footer and it was grey)

## QA
1. Go to  https://maas-io-660.demos.haus
2. Verify the home page works correctly and "Latest news" section has been removed

## Issue / Card

Fixes #655

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/7452681/145996867-7df5a2f3-e721-4197-8d6b-0f5ddfa6bb76.png)

### After
![image](https://user-images.githubusercontent.com/7452681/145996622-6ca723f5-959e-41cb-852a-6aa14690bfb4.png)
