### PR TITLE
Add bare metal K8s whitepaper to /resources, fix video link

### DIFF
--- a/templates/resources.html
+++ b/templates/resources.html
@@ -354,7 +354,7 @@ https://docs.google.com/document/d/1OXio660sPmWUllHW0CO8Dl24p6E6Jasl7be8szP6z-k/
       <div class="col-4">
         <p>
           Anton Smith, Product Manager for MAAS takes you hands-on to
-          <a href="https://www.youtube.com/watch?v=pPBqDzedjw0">
+          <a href="https://www.youtube.com/watch?v=sLADei_c9Qg">
             build your own simulated bare metal Kubernetes cluster</a
           >
           using just a single computer.
@@ -374,7 +374,7 @@ https://docs.google.com/document/d/1OXio660sPmWUllHW0CO8Dl24p6E6Jasl7be8szP6z-k/
           <iframe
             width="560"
             height="302"
-            src="https://www.youtube.com/embed/pPBqDzedjw0?controls=0"
+            src="https://www.youtube.com/embed/sLADei_c9Qg?controls=0"
             title="YouTube video player"
             frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -165,7 +165,6 @@ https://docs.google.com/document/d/1OXio660sPmWUllHW0CO8Dl24p6E6Jasl7be8szP6z-k/
           width="200"
           height="200"
         />
-        />
       </div>
     </div>
   </article>

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -133,6 +133,48 @@ https://docs.google.com/document/d/1OXio660sPmWUllHW0CO8Dl24p6E6Jasl7be8szP6z-k/
       <h2>Must reads</h2>
     </div>
   </div>
+  
+  <div class="row">
+  <article class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-4">
+        <h3 class="p-heading--4">
+          <a
+            href="https://ubuntu.com/engage/bare-metal-kubernetes"
+            >Easy and automated bare metal Kubernetes: The Definitive Whitepaper</a
+          >
+        </h3>
+      </div>
+      <div class="col-4">
+        <p>
+          Read the definitive whitepaper on bare metal Kubernetes featuring MAAS.
+        </p>
+        <p>
+          This whitepaper goes in depth into the history of VMs, how they compare with Kubernetes, and the important role bare metal orchestration (and MAAS) has to play.
+          Learn how to deploy Kubernetes on bare metal with MAAS, and the benefits that it has.
+          Designed to go hand in hand with the bare metal K8s video tutorial.
+        </p>
+        <p>
+          A textbook example of how MAAS is designed to be used to enable
+          automated bare metal provisioning.
+        </p>
+      </div>
+      <div class="col-4 u-align--center">
+        <img
+          alt=""
+          loading="lazy"
+          src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_207,h_251/https://lh3.googleusercontent.com/INmNUbiacgh9pSDKku0nh0XXtC9mlGIndW060gc-RLHrb23ZBBwvHXiJH-_S6V70sYbuLcsxOamr0cjjmVPScMKeahyVeuXIoqa8jp2c-dM-5IXs-tYO_wr9USVxjnvaWQb68XG-=s0"
+          srcset="
+            https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_414,h_502/https://lh3.googleusercontent.com/INmNUbiacgh9pSDKku0nh0XXtC9mlGIndW060gc-RLHrb23ZBBwvHXiJH-_S6V70sYbuLcsxOamr0cjjmVPScMKeahyVeuXIoqa8jp2c-dM-5IXs-tYO_wr9USVxjnvaWQb68XG-=s0 2x
+          "
+          width="207"
+          height="251"
+        />
+      </div>
+    </div>
+  </article>
+
+  <hr class="is-muted is-fixed-width" />
 
   <div class="row">
     <article class="p-strip is-shallow">

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -161,14 +161,10 @@ https://docs.google.com/document/d/1OXio660sPmWUllHW0CO8Dl24p6E6Jasl7be8szP6z-k/
       </div>
       <div class="col-4 u-align--center">
         <img
-          alt=""
-          loading="lazy"
-          src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_207,h_251/https://lh3.googleusercontent.com/INmNUbiacgh9pSDKku0nh0XXtC9mlGIndW060gc-RLHrb23ZBBwvHXiJH-_S6V70sYbuLcsxOamr0cjjmVPScMKeahyVeuXIoqa8jp2c-dM-5IXs-tYO_wr9USVxjnvaWQb68XG-=s0"
-          srcset="
-            https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_414,h_502/https://lh3.googleusercontent.com/INmNUbiacgh9pSDKku0nh0XXtC9mlGIndW060gc-RLHrb23ZBBwvHXiJH-_S6V70sYbuLcsxOamr0cjjmVPScMKeahyVeuXIoqa8jp2c-dM-5IXs-tYO_wr9USVxjnvaWQb68XG-=s0 2x
-          "
-          width="207"
-          height="251"
+          src="https://assets.ubuntu.com/v1/196ebe18-MAAS+Kubernetes.svg"
+          width="200"
+          height="200"
+        />
         />
       </div>
     </div>

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -154,10 +154,6 @@ https://docs.google.com/document/d/1OXio660sPmWUllHW0CO8Dl24p6E6Jasl7be8szP6z-k/
           Learn how to deploy Kubernetes on bare metal with MAAS, and the benefits that it has.
           Designed to go hand in hand with the bare metal K8s video tutorial.
         </p>
-        <p>
-          A textbook example of how MAAS is designed to be used to enable
-          automated bare metal provisioning.
-        </p>
       </div>
       <div class="col-4 u-align--center">
         <img


### PR DESCRIPTION
adds a new bm k8s wp to /resources
fixes the youtube link for the bm k8s video in /resources (which is incorrect - seems to have been reverted?)

Note: the image for the whitepaper might need to be checked, as uncertain where it should be hosted.