### PR TITLE
Up-lift install redirects from /docs/installation to the end URL

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,5 +1,5 @@
-get-started: "/docs/installation"
-install: "/docs/installation"
+get-started: "/docs/snap/3.1/ui/maas-installation"
+install: "/docs/snap/3.1/ui/maas-installation"
 index(.html)?: "/"
 (?P<path>.+)/index(.html)?: "{path}"
 

--- a/templates/how-it-works.html
+++ b/templates/how-it-works.html
@@ -154,7 +154,7 @@
             <br class="u-hide--medium u-hide--large" />
         </div>
         <div class="col-2 u-vertically-center">
-            <a aria-label="Find out how to install MAAS" href="/docs/installation" class="p-button--positive u-no-margin--bottom">Install MAAS</a>
+            <a aria-label="Find out how to install MAAS" href="/install" class="p-button--positive u-no-margin--bottom">Install MAAS</a>
         </div>
     </div>
 </section>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -7,7 +7,7 @@
           <a href="/">Home</a>
         </li>
         <li class="p-list__item">
-          <a href="/docs/installation">Install MAAS</a>
+          <a href="/install">Install MAAS</a>
         </li>
         <li class="p-list__item">
           <a href="/how-it-works">How it works</a>

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -13,7 +13,7 @@
     <nav class="p-navigation__nav" aria-label="main">
       <ul id="main-navigation" class="p-navigation__links u-clearfix">
         <li class="p-navigation__link">
-          <a href="/docs/installation" onclick="dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Install' });">Install</a>
+          <a href="/install" onclick="dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'Main navigation' , 'eventAction' : 'Click' , 'eventLabel' : 'Install' });">Install</a>
         </li>
         <li class="p-navigation__link{% if request.path.startswith('/how-it-works') %} is-selected" aria-current="page{% endif %}">
           <a href="/how-it-works" onclick="dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'Main navigation'

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
           <a href="/tutorials/build-a-maas-and-lxd-environment-in-30-minutes-with-multipass-on-ubuntu#1-overview" class="p-button--positive" itemprop="url">Try  MAAS on your PC in minutes</a>
         </li>
         <li class="p-inline-list__item">
-          <a aria-label="Find out how to install MAAS" href="/docs/installation" class="p-button" itemprop="url">Install MAAS</a>
+          <a aria-label="Find out how to install MAAS" href="/install" class="p-button" itemprop="url">Install MAAS</a>
         </li>
       </ul>
     </div>
@@ -90,7 +90,7 @@
               });"> Contact us </a>
         </li>
         <li class="p-inline-list__item u-no-margin--right">
-          <a class="p-button--positive u-no-margin--right" href="/docs/installation">Install today</a>
+          <a class="p-button--positive u-no-margin--right" href="/install">Install today</a>
         </li>
       </ul>
     </div>
@@ -723,7 +723,7 @@ document.addEventListener('DOMContentLoaded', function () {
           <tfoot>
             <tr>
               <td>&nbsp;</td>
-              <td><a href="/docs/installation">Install MAAS&nbsp;&rsaquo;</a></td>
+              <td><a href="/install">Install MAAS&nbsp;&rsaquo;</a></td>
               <td><a href="/contact-us" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });">Contact us&nbsp;&rsaquo;</a></td>
               <td><a href="/contact-us" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });">Contact us&nbsp;&rsaquo;</a></td>
               <td><a href="/contact-us" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });">Contact us&nbsp;&rsaquo;</a></td>


### PR DESCRIPTION
Take the redirect that was in Discourse docs and up-lift it to maas.io to avoid hitting slow path of parsing the topic document.

## Done

- Change redirect in redirects.yaml to avoid the middle-man /docs/installation redirect
- Change links to point to /install (and use the adjusted redirect)

## QA
Using e.g. DevTools verify that hitting http://$MAAS_WEBSITE/installation takes less than 500ms to respond with content

## Issue / Card

#622 

## Screenshots
