### PR TITLE
Replace download_asset with returnURL

### DIFF
--- a/templates/vmware-images.html
+++ b/templates/vmware-images.html
@@ -54,8 +54,7 @@
               <button type="submit" class="p-button--positive">Download template</button>
             </div>
             <input type="hidden" name="formid" value="3392">
-            <input type="hidden" name="download_asset_url" value="https://github.com/canonical/packer-maas/archive/1.0.3.tar.gz">
-            <input type="hidden" name="returnURL" value="">
+            <input type="hidden" name="returnURL" value="https://github.com/canonical/packer-maas/archive/1.0.3.tar.gz">
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Done
Replace the download asset field with the returnURL on the form.

## QA
- Go to /vmware-images and fill in the form
- Check you the browser downloads the asset

Fixes https://sentry.is.canonical.com/canonical/ubuntu-com/issues/24080/?query=is%3Aunresolved
