### PR TITLE
Remove circleci badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 MAAS website project
 ===
 
-[![CircleCI build status](https://circleci.com/gh/canonical-web-and-design/maas.io.svg?style=shield)](https://circleci.com/gh/canonical-web-and-design/maas.io)
 [![Code coverage](https://codecov.io/gh/canonical-web-and-design/maas.io/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/maas.io)
 
 This is the simple Flask project behind <https://maas.io>.


### PR DESCRIPTION
## Done

- Remove circleci badge from readme (as we no longer use it)
