### PR TITLE
Mark cchardet as optional for `aarch64`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ canonicalwebteam.image-template==1.3.1
 feedparser==6.0.8
 requests-cache==0.9.1
 lxml==4.7.1
-cchardet==2.1.7
+cchardet==2.1.7; platform_machine != 'aarch64'


### PR DESCRIPTION

## Done

Used PEP 508 environment markers (see https://pip.pypa.io/en/latest/cli/pip_install/#requirement-specifiers) to mark `cchardet` as optional on `aarch64` whilst retaining it for other platforms.

## QA

* [amd64] Confirm dotrun includes cchardet in the environment
* [aarch64] Confirm dotrun succeeds and doesn't include cchardet in the environment

## Issue / Card

Fixes #698

## Screenshots
