### PR TITLE
fix(a11y): add label to document contents navigation sidebar

### DIFF
--- a/templates/docs/api.html
+++ b/templates/docs/api.html
@@ -14,7 +14,7 @@
     </div>
   </section>
   <div class="l-docs">
-    <aside class="l-docs-sidebar" id="navigation">
+    <aside class="l-docs-sidebar" id="navigation" aria-label="document contents">
       <i class="p-sidenav__toggle p-icon--menu u-hide--medium u-hide--large"></i>
       <nav class="p-sidenav__body u-hide--small">
         {{ navigation | safe }}

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -19,7 +19,7 @@
     </div>
   </section>
   <div class="l-docs">
-    <aside class="l-docs-sidebar" id="navigation">
+    <aside class="l-docs-sidebar" id="navigation" aria-label="document contents">
       <i class="p-sidenav__toggle p-icon--menu u-hide u-show--small"></i>
       <nav class="p-sidenav__body u-hide--small">
         {{ navigation | safe }}

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -13,7 +13,7 @@
 
 <div class="l-docs-wrapper">
   <div class="l-docs">
-    <aside class="l-docs-sidebar" id="navigation">
+    <aside class="l-docs-sidebar" id="navigation" aria-label="document contents">
       <i class="p-sidenav__toggle p-icon--menu u-hide--medium u-hide--large"></i>
       <nav class="p-sidenav__body u-hide--small">
         <ol class="p-tutorial__nav">


### PR DESCRIPTION
## Done

- add label to document contents

## Issue
This fixes accessibility violation reported by `axe`:
[Landmarks must have a unique role or role/label/title (i.e. accessible name) combination](https://dequeuniversity.com/rules/axe/4.4/landmark-unique?application=AxeChrome)

## Issue / Card


## Screenshots

### Before
![image](https://user-images.githubusercontent.com/7452681/155733316-017b3977-9f58-42a8-8c21-48bc77b19d7e.png)

### After
<img width="1353" alt="Screenshot 2022-02-25 at 15 34 17" src="https://user-images.githubusercontent.com/7452681/155733164-cc390d53-0e57-434f-8385-cc43ebb42abc.png">

