### PR TITLE
Remove a looping redirect in redirects.yaml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -363,7 +363,6 @@ docs/custom-node-setup-preseed: /docs/snap/3.1/ui/how-to-customise-machines
 docs/dhcp: /docs/snap/3.1/ui/how-to-manage-dhcp
 docs/disk-erasure: /docs/snap/3.1/ui/how-to-manage-machines
 docs/explore-maas: /docs/snap/3.1/ui/maas-installation 
-docs/get-started-with-maas: /docs/snap/3.1/ui/give-me-an-example-of-maas 
 docs/getting-help: /docs/snap/3.1/ui/getting-help 
 docs/hardware-test-scripts: /docs/snap/3.1/ui/hardware-test-scripts-reference 
 docs/hardware-testing: /docs/snap/3.1/ui/how-to-deploy-machines


### PR DESCRIPTION
Part of converting RAD >> tabs.  Pointing all RAD URLs at new base URLs (e.g., /snap/3.1/ui/get-started-with-maas becomes just /get-started-with-maas).  Converted the latest docs (/snap/3.1/ui) to tab versions, all RAD URLs get redirected to new tab version.  To get started, just created redirects in MAAS index file, so I don't have to wait for a merge to check my work.

Currently, MAAS doc index file point /snap/3.1/ui/give-me-an-example-of-maas >>  /get-started-with-maas; redirects.yaml points get-started-with-maas >> /give-me-an-example-of-maas.  Will move index file redirects into this yaml file later, just fixing redirect loop for now.

## Done

Removed redirect in redirects.yaml for now. Will be moving redirects from MAAS index file over to this yaml file as soon as all other RAD >> tabs work & fixes are done, separate PR to come later.
