### PR TITLE
Bump dependency canonicalwebteam.flask_base to 1.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask_base==1.0.1
+canonicalwebteam.flask_base==1.0.3
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.discourse-docs==1.0.1
 canonicalwebteam.http==1.0.3


### PR DESCRIPTION
## Done

Bumped canonicalwebteam.flask_base to 1.0.3 on @albertkol 's advice

## QA

CI passes

## Issue / Card
https://github.com/canonical-web-and-design/canonicalwebteam.flask-base/pull/57
