### PR TITLE
Fix links and add page to footer on /support

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -24,6 +24,9 @@
         <li class="p-list__item">
           <a href="/contact-us">Contact us</a>
         </li>
+        <li class="p-list__item">
+          <a href="/support">Support</a>
+        </li>
       </ul>
     </div>
 

--- a/templates/support.html
+++ b/templates/support.html
@@ -48,7 +48,7 @@
   <div class="row">
     <div class="col-6">
       <h2>Ubuntu Advantage for Infrastructure</h2>
-      <p>Support and commercial capabilities for MAAS are included with <a href="/pricing/infra">Ubuntu Advantage for Infrastructure</a> (UA-I). This support is charged on a per-machine basis. For example, if UA-I is purchased for 100 machines, then MAAS support is also included for those 100 machines.</p>
+      <p>Support and commercial capabilities for MAAS are included with <a href="https://www.ubuntu.com/pricing/infra">Ubuntu Advantage for Infrastructure</a> (UA-I). This support is charged on a per-machine basis. For example, if UA-I is purchased for 100 machines, then MAAS support is also included for those 100 machines.</p>
     </div>
   </div>
 </section>
@@ -109,10 +109,10 @@
         </tr>
         <tr>
           <th></th>
-          <td class="u-align--center"><a href="https://www.ubuntu.com/download/server/provisioning">Install MAAS</a></td>
-          <td class="u-align--center"><a href="https://www.ubuntu.com/server/maas/contact-us">Contact us</a></td>
-          <td class="u-align--center"><a href="https://www.ubuntu.com/server/maas/contact-us">Contact us</a></td>
-          <td class="u-align--center"><a href="https://www.ubuntu.com/server/maas/contact-us">Contact us</a></td>
+          <td class="u-align--center"><a href="/docs/how-to-install-maas">Install MAAS</a></td>
+          <td class="u-align--center"><a href="/contact-us">Contact us</a></td>
+          <td class="u-align--center"><a href="/contact-us">Contact us</a></td>
+          <td class="u-align--center"><a href="/contact-us">Contact us</a></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Done

- Fixed "Ubuntu Advantage for Infrastructure" link
- Changed pricing links on table to remain on the maas.io site instead
- Added page to footer
- Copy doc [here](https://docs.google.com/document/d/1oEF37NP9bDuKQpKBQjUfWleN3yQ3QRUp9d2pLiKryCg/edit#)

## QA

- Visit the page at https://maas-io-736.demos.haus/support 
- Check that the updated links and footer work as expected  
