### PR TITLE
Remove the 3.1 release banner

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -49,7 +49,6 @@
     {% include "includes/header.html" %}
 
     <main class="u-no-margin--top {% block content_class %}{% endblock %}" id="main-content">
-      {% include "includes/banner.html" %}
       {% block content %}{% endblock %}
     </main>
 

--- a/templates/includes/banner.html
+++ b/templates/includes/banner.html
@@ -1,7 +1,0 @@
-<section class="p-strip--light is-shallow">
-  <div class="u-fixed-width">
-    <strong>MAAS 3.1 has been released. Find out
-      <a href="/docs/snap/3.1/ui/whats-new-in-maas">what’s new in 3.1.</a>
-    </strong>
-  </div>
-</section>


### PR DESCRIPTION
## Done
Remove the 3.1 release banner

## QA
- Open the demo
- Click through the site and check the main templates work without the banner

## Issue / Card
Fixes https://github.com/canonical-web-and-design/maas.io/issues/738
