### PR TITLE
Fix link to SASS files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ When you start changing files, the server should reload and make the changes ava
 
 ### Building CSS
 
-For working on [Sass files](_sass), you may want to dynamically watch for changes to rebuild the CSS whenever something changes.
+For working on [Sass files](static/sass), you may want to dynamically watch for changes to rebuild the CSS whenever something changes.
 
 To setup the watcher, open a new terminal window and run:
 


### PR DESCRIPTION
## Done

Fixed README link to SASS files

## QA

Click link in README on GitHub, verify that it links to `static/sass/`

## Issue / Card

## Screenshots
