### PR TITLE
update maas favicon image assets

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -14,8 +14,10 @@
     <!-- stylesheets -->
     <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/main.css') }}" />
 
-    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/6284d208-maas-favicon-16px.png" sizes="16x16" />
-    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/5922a009-maas-favicon-32px.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/c555447f-maas-2022-favicon-16.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/6cce4f7c-maas-2022-favicon-32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/bdcff402-maas-2022-favicon-64.png" sizes="64x64" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/7baeacdb-maas-2022-favicon-128.png" sizes="128x128" />
 
     <meta name="google-site-verification" content="oJqEviYsw1FaDzCq7kzhewyJ2enm5vk9Q-prliavhjw" />
     <meta name="description" content="{% block page_description %}MAAS (Metal as a Service) offers cloud style provisioning for physical servers. It is open source and free to use, with commercial support available from Canonical.{% endblock %}" />


### PR DESCRIPTION
## Done

update maas favicon image assets

## QA

Verify that the new square maas image asset is used for the favicon

## Issue / Card

Fixes #755 
Fixes https://github.com/canonical-web-and-design/app-tribe/issues/1163

## Screenshots

[if relevant, include a screenshot]
